### PR TITLE
refactor: 重構角色卡產生器介面為精品雜誌風格

### DIFF
--- a/tools/character-card/style.css
+++ b/tools/character-card/style.css
@@ -968,9 +968,9 @@
 
 /*
  * Selected Display - Elegant Card
- * Note: display is controlled by JavaScript (script.js lines 636, 650)
+ * Note: Visibility is dynamically controlled by JavaScript selection handlers
  * - Hidden by default: display: none
- * - Shown when selected: style.display = 'flex' (via JavaScript)
+ * - Shown when user selects a server/job: display = 'flex'
  */
 .selected-server {
     display: none;
@@ -1199,6 +1199,29 @@
 
     .character-card {
         box-shadow: none;
+    }
+
+    /* Reset all animated elements to ensure visibility when printing */
+    .character-name,
+    .job-name,
+    .info-line,
+    .job-icon {
+        animation: none !important;
+        opacity: 1 !important;
+        transform: none !important;
+    }
+
+    .character-name::after {
+        animation: none !important;
+        width: 80px !important;
+    }
+
+    /* Globally disable all animations and transitions for print */
+    *,
+    *::before,
+    *::after {
+        animation: none !important;
+        transition: none !important;
     }
 }
 


### PR DESCRIPTION
採用高級編輯設計美學，靈感來自高端遊戲雜誌與珍藏版藝術畫冊

主要變更：
- 採用 Cinzel、Crimson Pro、DM Sans 字型組合打造精緻排版
- 深邃海軍藍背景搭配奢華金色點綴色系
- 角色名稱採用大寫 Cinzel 字型與漸層金色效果
- 新增裝飾性邊角框線，hover 時發光效果
- 職業圖示加入閃光動畫與立體陰影
- 所有卡片元素採用流暢的淡入上移動畫
- 表單介面加入精緻的聚焦動畫與過渡效果
- 選擇按鈕採用光澤穿透動畫
- 自訂範圍滑桿樣式，金色漸層滑塊
- 優化響應式設計，各螢幕尺寸皆流暢縮放

🤖 Generated with [Claude Code](https://claude.com/claude-code)