### PR TITLE
fix: 修正導航列語言選單對齊問題並簡化按鈕文字

### DIFF
--- a/about.html
+++ b/about.html
@@ -216,18 +216,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/assets/css/components/language-switcher.css
+++ b/assets/css/components/language-switcher.css
@@ -9,7 +9,6 @@
     display: flex;
     gap: 0.25rem;
     align-items: center;
-    margin-left: 1rem;
     padding: 0.25rem;
     background: rgba(255, 255, 255, 0.1);
     border-radius: 8px;
@@ -64,23 +63,8 @@
     background: white;
 }
 
-/* 國旗 emoji */
-.lang-flag {
-    font-size: 1rem;
-    line-height: 1;
-}
-
-/* 語言名稱 - 桌面版顯示 */
-.lang-name {
-    display: none;
-}
-
-/* 響應式：平板及以上顯示語言名稱 */
+/* 響應式：平板及以上 */
 @media (min-width: 768px) {
-    .lang-name {
-        display: inline;
-    }
-
     .language-btn {
         padding: 0.375rem 0.75rem;
     }
@@ -90,17 +74,12 @@
 @media (max-width: 767px) {
     .language-switcher {
         /* 手機版保持緊湊 */
-        margin-left: 0.5rem;
         padding: 0.125rem;
         gap: 0.125rem;
     }
 
     .language-btn {
         padding: 0.375rem 0.5rem;
-    }
-
-    .lang-flag {
-        font-size: 1.125rem;
     }
 }
 
@@ -117,10 +96,6 @@
 
     .nav.nav-open .language-btn {
         padding: 0.5rem 1rem;
-    }
-
-    .nav.nav-open .lang-name {
-        display: inline;
     }
 }
 

--- a/changelog.html
+++ b/changelog.html
@@ -26,18 +26,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/copyright.html
+++ b/copyright.html
@@ -197,18 +197,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/index.html
+++ b/index.html
@@ -312,18 +312,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/tools/character-card/index.html
+++ b/tools/character-card/index.html
@@ -31,18 +31,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/tools/dungeon-database/index.html
+++ b/tools/dungeon-database/index.html
@@ -31,18 +31,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/tools/faux-hollows-foxes/index.html
+++ b/tools/faux-hollows-foxes/index.html
@@ -28,18 +28,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/tools/lodestone-lookup/index.html
+++ b/tools/lodestone-lookup/index.html
@@ -38,18 +38,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/tools/mini-cactpot/index.html
+++ b/tools/mini-cactpot/index.html
@@ -28,18 +28,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/tools/timed-gathering/index.html
+++ b/tools/timed-gathering/index.html
@@ -28,18 +28,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/tools/treasure-map-finder/index.html
+++ b/tools/treasure-map-finder/index.html
@@ -28,18 +28,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>

--- a/tools/wondrous-tails/index.html
+++ b/tools/wondrous-tails/index.html
@@ -28,18 +28,9 @@
                     </div>
                 </div>
                 <div class="language-switcher">
-                    <button class="language-btn" data-lang="zh" aria-pressed="false">
-                        <span class="lang-flag">🇹🇼</span>
-                        <span class="lang-name">中文</span>
-                    </button>
-                    <button class="language-btn" data-lang="en" aria-pressed="false">
-                        <span class="lang-flag">🇺🇸</span>
-                        <span class="lang-name">EN</span>
-                    </button>
-                    <button class="language-btn" data-lang="ja" aria-pressed="false">
-                        <span class="lang-flag">🇯🇵</span>
-                        <span class="lang-name">日本語</span>
-                    </button>
+                    <button class="language-btn" data-lang="zh" aria-pressed="false">ZH-TW</button>
+                    <button class="language-btn" data-lang="en" aria-pressed="false">EN</button>
+                    <button class="language-btn" data-lang="ja" aria-pressed="false">JP</button>
                 </div>
             </nav>
         </div>


### PR DESCRIPTION
- 移除 language-switcher 的 margin-left 以修正對齊問題
- 簡化語言按鈕為 ZH-TW / EN / JP（移除國旗與長文字）
- 清理 CSS 中不再使用的 .lang-flag 和 .lang-name 樣式

🤖 Generated with [Claude Code](https://claude.com/claude-code)