### PR TITLE
feat: 新增攻略資料工具

### DIFF
--- a/assets/js/i18n/translations/index.js
+++ b/assets/js/i18n/translations/index.js
@@ -36,6 +36,9 @@ const IndexTranslations = {
         tool_timed_gathering_title: '特殊採集時間管理器',
         tool_timed_gathering_desc: '管理 FF14 特殊採集時間，支援搜尋、多清單管理與巨集匯出',
 
+        tool_guide_title: '攻略資料',
+        tool_guide_desc: 'FF14 新手攻略指南，包含公會、軍階、副本、風脈與探索筆記說明',
+
         tool_equipment_analyzer_title: '裝備分析器',
         tool_equipment_analyzer_desc: '分析裝備屬性和配裝建議，提供最佳配裝方案',
 
@@ -77,6 +80,9 @@ const IndexTranslations = {
         tool_timed_gathering_title: 'Timed Gathering Manager',
         tool_timed_gathering_desc: 'Manage FF14 timed gathering nodes with search, lists, and macro export',
 
+        tool_guide_title: 'Game Guide',
+        tool_guide_desc: 'FF14 beginner guide covering guilds, ranks, dungeons, aether currents, and sightseeing log',
+
         tool_equipment_analyzer_title: 'Equipment Analyzer',
         tool_equipment_analyzer_desc: 'Analyze equipment stats and provide optimal gear recommendations',
 
@@ -117,6 +123,9 @@ const IndexTranslations = {
 
         tool_timed_gathering_title: 'タイムド採集管理',
         tool_timed_gathering_desc: 'FF14タイムド採集を検索、リスト、マクロエクスポートで管理',
+
+        tool_guide_title: '攻略情報',
+        tool_guide_desc: 'FF14初心者ガイド。FC、GC階級、ダンジョン、風脈、探検手帳を含む',
 
         tool_equipment_analyzer_title: '装備分析器',
         tool_equipment_analyzer_desc: '装備ステータスを分析し、最適な装備を提案',

--- a/assets/js/i18n/translations/tools/guide.js
+++ b/assets/js/i18n/translations/tools/guide.js
@@ -1,0 +1,136 @@
+/**
+ * FF14.tw 攻略資料翻譯檔
+ */
+const GuideTranslations = {
+    zh: {
+        // 頁面資訊
+        guide_title: '攻略資料 - FF14.tw',
+        guide_description: 'FF14 新手攻略指南，包含公會系統、軍階、副本、風脈、探索筆記與專屬陸行鳥完整說明',
+
+        // 頁面標題
+        guide_header: '攻略資料',
+
+        // Landing page
+        guide_landing_desc: '選擇主題開始閱讀',
+        guide_back_to_index: '← 返回總覽',
+
+        // 目錄
+        guide_toc_title: '目錄',
+        guide_toc_guild: '公會',
+        guide_toc_grand_company: '大國防聯軍',
+        guide_toc_dungeon: '副本',
+        guide_toc_aether: '風脈',
+        guide_toc_sightseeing: '探索筆記',
+
+        // 卡片描述
+        guide_guild_desc: '部隊系統、加入方式與福利',
+        guide_grand_company_desc: '三大軍團、軍階系統與軍票',
+        guide_dungeon_desc: '副本類型與開放條件',
+        guide_aether_desc: '風脈泉解鎖與飛行系統',
+        guide_sightseeing_desc: '探索筆記機制與獎勵',
+
+        // 章節標題
+        guide_section_guild_title: '公會',
+        guide_section_grand_company_title: '大國防聯軍',
+        guide_section_dungeon_title: '副本',
+        guide_section_aether_title: '風脈',
+        guide_section_sightseeing_title: '探索筆記',
+        guide_section_chocobo_title: '專屬陸行鳥',
+
+        // 陸行鳥
+        guide_toc_chocobo: '專屬陸行鳥',
+        guide_chocobo_desc: '陸行鳥夥伴系統與養成指南',
+
+        // 準備中
+        guide_coming_soon: '本頁面內容準備中，敬請期待！'
+    },
+    en: {
+        // Page info
+        guide_title: 'Game Guide - FF14.tw',
+        guide_description: 'FF14 beginner guide covering Free Company, Grand Company ranks, dungeons, aether currents, sightseeing log, and Chocobo Companion',
+
+        // Page header
+        guide_header: 'Game Guide',
+
+        // Landing page
+        guide_landing_desc: 'Select a topic to start reading',
+        guide_back_to_index: '← Back to Overview',
+
+        // Table of contents
+        guide_toc_title: 'Contents',
+        guide_toc_guild: 'Free Company',
+        guide_toc_grand_company: 'Grand Company',
+        guide_toc_dungeon: 'Dungeons',
+        guide_toc_aether: 'Aether Currents',
+        guide_toc_sightseeing: 'Sightseeing Log',
+
+        // Card descriptions
+        guide_guild_desc: 'FC system, how to join, and benefits',
+        guide_grand_company_desc: 'Three nations, ranks and company seals',
+        guide_dungeon_desc: 'Dungeon types and unlock requirements',
+        guide_aether_desc: 'Aether currents and flying unlock',
+        guide_sightseeing_desc: 'Sightseeing log mechanics and rewards',
+
+        // Section titles
+        guide_section_guild_title: 'Free Company',
+        guide_section_grand_company_title: 'Grand Company',
+        guide_section_dungeon_title: 'Dungeons',
+        guide_section_aether_title: 'Aether Currents',
+        guide_section_sightseeing_title: 'Sightseeing Log',
+        guide_section_chocobo_title: 'Chocobo Companion',
+
+        // Chocobo
+        guide_toc_chocobo: 'Chocobo Companion',
+        guide_chocobo_desc: 'Chocobo companion system and training guide',
+
+        // Coming soon
+        guide_coming_soon: 'This page is under construction. Stay tuned!'
+    },
+    ja: {
+        // ページ情報
+        guide_title: '攻略情報 - FF14.tw',
+        guide_description: 'FF14初心者ガイド。フリーカンパニー、グランドカンパニー階級、ダンジョン、風脈、探検手帳、バディチョコボの完全ガイド',
+
+        // ページヘッダー
+        guide_header: '攻略情報',
+
+        // ランディングページ
+        guide_landing_desc: 'トピックを選んで読み始める',
+        guide_back_to_index: '← 概要に戻る',
+
+        // 目次
+        guide_toc_title: '目次',
+        guide_toc_guild: 'フリーカンパニー',
+        guide_toc_grand_company: 'グランドカンパニー',
+        guide_toc_dungeon: 'ダンジョン',
+        guide_toc_aether: '風脈',
+        guide_toc_sightseeing: '探検手帳',
+
+        // カード説明
+        guide_guild_desc: 'FCシステム、参加方法、特典',
+        guide_grand_company_desc: '三国軍、階級システムと軍票',
+        guide_dungeon_desc: 'ダンジョンの種類と開放条件',
+        guide_aether_desc: '風脈の解放とフライング',
+        guide_sightseeing_desc: '探検手帳の仕組みと報酬',
+
+        // セクションタイトル
+        guide_section_guild_title: 'フリーカンパニー',
+        guide_section_grand_company_title: 'グランドカンパニー',
+        guide_section_dungeon_title: 'ダンジョン',
+        guide_section_aether_title: '風脈',
+        guide_section_sightseeing_title: '探検手帳',
+        guide_section_chocobo_title: 'バディチョコボ',
+
+        // チョコボ
+        guide_toc_chocobo: 'バディチョコボ',
+        guide_chocobo_desc: 'バディチョコボシステムと育成ガイド',
+
+        // 準備中
+        guide_coming_soon: 'このページは準備中です。お楽しみに！'
+    }
+};
+
+// 載入翻譯到全域 i18n
+if (window.i18n) {
+    window.i18n.loadTranslations('guide', GuideTranslations);
+}

--- a/index.html
+++ b/index.html
@@ -368,6 +368,12 @@
                         <p class="tool-description" data-i18n="tool_timed_gathering_desc">管理 FF14 特殊採集時間，支援搜尋、多清單管理與巨集匯出</p>
                     </a>
 
+                    <a href="tools/guide/index.html" class="tool-card available">
+                        <div class="tool-icon">📖</div>
+                        <h3 class="tool-title" data-i18n="tool_guide_title">攻略資料</h3>
+                        <p class="tool-description" data-i18n="tool_guide_desc">FF14 新手攻略指南，包含公會、軍階、副本、風脈與探索筆記說明</p>
+                    </a>
+
                     <div class="tool-card coming-soon">
                         <span class="status-badge coming-soon" data-i18n="status_coming_soon">即將推出</span>
                         <div class="tool-icon">⚔️</div>

--- a/tools/guide/aether.html
+++ b/tools/guide/aether.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>風脈 - 攻略資料 - FF14.tw</title>
+    <meta name="description" content="FF14 風脈系統完整說明，包含風脈收集方式、以太羅盤使用與各資料片地圖">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+
+    <!-- Required CSS imports -->
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- Header placeholder -->
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="攻略資料" data-tool-name-key="guide_header"></div>
+
+    <!-- Noscript fallback -->
+    <noscript>
+        <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
+            <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
+            <a href="/copyright.html" style="color: white; margin: 0 1rem;">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" style="color: white; margin: 0 1rem;">GitHub</a>
+            <a href="/about.html" style="color: white; margin: 0 1rem;">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container guide-layout">
+            <!-- Sidebar placeholder -->
+            <div id="guide-sidebar-placeholder" data-current-page="aether"></div>
+
+            <!-- Main Content Wrapper -->
+            <div class="guide-content-wrapper">
+                <article class="guide-article">
+                    <h1 class="article-title">
+                        <span class="article-icon">💨</span>
+                        <span data-i18n="guide_section_aether_title">風脈</span>
+                    </h1>
+                    <div class="article-content">
+                        <div class="coming-soon">
+                            <p data-i18n="guide_coming_soon">本頁面內容準備中，敬請期待！</p>
+                        </div>
+                    </div>
+                </article>
+
+                <!-- Page Navigation -->
+                <nav class="page-nav">
+                    <a href="dungeon.html" class="page-nav-prev">
+                        ← <span data-i18n="guide_toc_dungeon">副本</span>
+                    </a>
+                    <a href="sightseeing.html" class="page-nav-next">
+                        <span data-i18n="guide_toc_sightseeing">探索筆記</span> →
+                    </a>
+                </nav>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <!-- Required JS imports -->
+    <script src="../../assets/js/i18n/i18n-manager.js"></script>
+    <script src="../../assets/js/i18n/translations/common.js"></script>
+    <script src="../../assets/js/i18n/translations/tools/guide.js"></script>
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+    <script src="sidebar-template.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/guide/chocobo.html
+++ b/tools/guide/chocobo.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>專屬陸行鳥 - 攻略資料 - FF14.tw</title>
+    <meta name="description" content="FF14 專屬陸行鳥完整指南，包含夥伴系統、養成方式、技能配點與戰術指令">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+
+    <!-- Required CSS imports -->
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- Header placeholder -->
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="攻略資料" data-tool-name-key="guide_header"></div>
+
+    <!-- Noscript fallback -->
+    <noscript>
+        <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
+            <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
+            <a href="/copyright.html" style="color: white; margin: 0 1rem;">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" style="color: white; margin: 0 1rem;">GitHub</a>
+            <a href="/about.html" style="color: white; margin: 0 1rem;">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container guide-layout">
+            <!-- Sidebar placeholder -->
+            <div id="guide-sidebar-placeholder" data-current-page="chocobo"></div>
+
+            <!-- Main Content Wrapper -->
+            <div class="guide-content-wrapper">
+                <article class="guide-article">
+                    <h1 class="article-title">
+                        <span class="article-icon">🐤</span>
+                        <span data-i18n="guide_section_chocobo_title">專屬陸行鳥</span>
+                    </h1>
+                    <div class="article-content">
+                        <h2>關於專屬陸行鳥</h2>
+                        <p>在艾歐澤亞的冒險中，陸行鳥不只是帶著你四處奔跑的交通工具，更能成為與你並肩作戰的可靠夥伴。透過培養與訓練，你的陸行鳥可以在野外戰鬥中提供治療、攻擊或防護支援。</p>
+
+                        <h2>開放條件總覽</h2>
+                        <p>以下是陸行鳥相關功能的解鎖條件：</p>
+
+                        <h3>取得專屬陸行鳥</h3>
+                        <p>首先需完成主線任務「英雄之卵」並加入三大軍之一，接著完成對應的陸行鳥任務：</p>
+                        <ul>
+                            <li><strong>黑渦團：</strong>「我的專屬陸行鳥」（利姆薩·羅敏薩）</li>
+                            <li><strong>雙蛇黨：</strong>「我的專屬陸行鳥」（格里達尼亞）</li>
+                            <li><strong>恆輝隊：</strong>「我的專屬陸行鳥」（烏爾達哈）</li>
+                        </ul>
+
+                        <h3>其他進階功能</h3>
+                        <ul>
+                            <li><strong>夥伴功能：</strong>完成任務「可靠的夥伴」</li>
+                            <li><strong>陸行鳥房寄養：</strong>完成任務「培育陸行鳥的秘訣」</li>
+                            <li><strong>野外飛行：</strong>2.0 地區完成「超越幻想，究極神兵」；後續版本需開啟該地圖全部風脈</li>
+                        </ul>
+
+                        <div class="guide-info-card guide-tip">
+                            <strong>提示：</strong>完成主線加入軍隊後，記得回軍部領取陸行鳥笛！這是獲得專屬坐騎的重要一步。
+                        </div>
+
+                        <h2>召喚與管理夥伴</h2>
+                        <p>取得夥伴功能後，你可以在野外召喚陸行鳥協助作戰。</p>
+
+                        <h3>召喚方式</h3>
+                        <p>使用「基沙爾野菜」即可召喚夥伴，每次消耗一個道具可維持 30 分鐘，最多可累積至 60 分鐘。建議將此道具放入快捷列以便使用。基沙爾野菜可於各地雜貨商購得。</p>
+
+                        <h3>解散夥伴</h3>
+                        <p>夥伴會在戰鬥不能或時間結束後自動離開。若需手動解散，可開啟「角色」→「夥伴」視窗，使用「離開」指令。</p>
+
+                        <div class="guide-info-card guide-note">
+                            <strong>小知識：</strong>夥伴在副本內無法召喚，但在野外打怪、完成 FATE 時是很好的幫手！
+                        </div>
+
+                        <h2>陸行鳥鞍囊</h2>
+                        <p>鞍囊是一個額外的 70 格儲存空間，可在副本外隨時存取。即使未召喚陸行鳥或將其寄養在陸行鳥房，鞍囊依然可以使用。</p>
+
+                        <h3>使用注意事項</h3>
+                        <ul>
+                            <li>開啟方式：「角色」→「陸行鳥鞍囊」</li>
+                            <li>僅能持有一個的特殊裝備放入鞍囊後，可再次獲得第二個，但無法將兩個都放入鞍囊</li>
+                            <li>一次性使用道具（如秘籍）使用前放入鞍囊，可再次兌換，請小心避免重複兌換</li>
+                        </ul>
+
+                        <h2>外觀自訂</h2>
+
+                        <h3>改名</h3>
+                        <p>可在以下地點為陸行鳥改名：</p>
+                        <ul>
+                            <li><strong>利姆薩·羅敏薩下層甲板：</strong>弗雷蓋姆 (X: 12.1, Y: 11)</li>
+                            <li><strong>格里達尼亞新街：</strong>辛格爾 (X: 11.8, Y: 12.6)</li>
+                            <li><strong>烏爾達哈現世回廊：</strong>米米古恩 (X: 12.3, Y: 8.3)</li>
+                            <li>個人房屋或部隊房屋的陸行鳥房</li>
+                        </ul>
+
+                        <h3>裝甲與染色</h3>
+                        <p>夥伴可裝備頭部、身體、腿部三個部位的陸行鳥裝甲。裝甲僅影響外觀，不會改變能力數值。此外，還可以透過特殊飼料改變陸行鳥的羽毛顏色。</p>
+
+                        <h2>寄養系統</h2>
+                        <p>擁有個人房屋、公會房屋或公寓的玩家，可在陸行鳥房寄養夥伴進行訓練。</p>
+
+                        <h3>寄養功能</h3>
+                        <ul>
+                            <li>寄養期間可進行改名、餵食、訓練</li>
+                            <li>寄養中的夥伴無法在野外召喚</li>
+                            <li>寄養前請先解散野外的夥伴</li>
+                        </ul>
+
+                        <h3>走失找回</h3>
+                        <p>若在失去房屋權限前未領回陸行鳥（如退出公會或房屋到期），系統會提示「夥伴陸行鳥走失了」。可前往原住宅區的房屋大叔處找回，房屋大叔通常位於住宅區傳送點附近。</p>
+
+                        <div class="guide-info-card guide-warning">
+                            <strong>注意：</strong>退出公會或放棄房屋前，請記得先領回寄養的陸行鳥！
+                        </div>
+
+                        <h2>夥伴養成</h2>
+                        <p>夥伴擁有獨立的技能等級系統，透過戰鬥累積經驗可以學習更多技能。</p>
+
+                        <h3>技能等級與點數</h3>
+                        <p>夥伴的技能等級與職業等級分開計算。每擊敗一個敵人，夥伴會獲得技能經驗。等級提升時會獲得技能點數：</p>
+                        <ul>
+                            <li>初始：10 點</li>
+                            <li>1-9 級：每級獲得等同級數的點數</li>
+                            <li>10-16 級：每級固定 10 點</li>
+                            <li>17-20 級：每級獲得（級數 - 6）點</li>
+                        </ul>
+                        <p>滿級後可習得所有技能。</p>
+
+                        <h3>三大技能路線</h3>
+                        <p>技能點數可分配至三條路線，每條需依序學習：</p>
+
+                        <h4>防護路線</h4>
+                        <p>提升仇恨與防禦能力，適合希望陸行鳥擔任坦克角色的玩家。主要技能包括陸行鳥後撞、陸行鳥踢擊、陸行鳥防禦等。學滿 10 級可獲得防護系陸行鳥裝甲。</p>
+
+                        <h4>治療路線</h4>
+                        <p>提供回復能力，可為玩家持續補血。主要技能包括陸行鳥再生、陸行鳥治療、陸行鳥波濤等。學滿 10 級可獲得治療系陸行鳥裝甲。</p>
+
+                        <h4>攻擊路線</h4>
+                        <p>強化輸出傷害，提升戰鬥效率。主要技能包括陸行鳥裂斬、陸行鳥猛啄、陸行鳥衝刺等。學滿 10 級可獲得攻擊系陸行鳥裝甲。</p>
+
+                        <div class="guide-info-card guide-tip">
+                            <strong>提示：</strong>每條路線學滿需要 55 點技能點。建議先專精一條路線再發展其他。可使用「里根圓椒」重置技能點數。
+                        </div>
+
+                        <h3>訓練飼料</h3>
+                        <p>在野外或陸行鳥房可餵食特殊飼料獲得增益效果：</p>
+                        <ul>
+                            <li><strong>庫里爾蘿蔔：</strong>經驗值提高</li>
+                            <li><strong>希爾奇斯菜薊：</strong>攻擊力提高</li>
+                            <li><strong>米梅特葫蘆：</strong>魔法治療力提高</li>
+                            <li><strong>坦塔爾矮瓜：</strong>最大體力提高</li>
+                            <li><strong>帕薩納紅茄：</strong>仇恨提高</li>
+                            <li><strong>克拉卡蘿蔔：</strong>瞬間提升技能經驗（1 小時冷卻）</li>
+                            <li><strong>薩維奈圓蔥：</strong>突破等級上限（10 級以上，共需 10 個）</li>
+                        </ul>
+                        <p>在陸行鳥房連續使用同種飼料訓練 10 次後，該飼料會成為「喜歡的飼料」，在野外使用時效果更強。</p>
+
+                        <h2>夥伴戰術</h2>
+                        <p>可透過指令調整夥伴的戰鬥行為：</p>
+                        <ul>
+                            <li><strong>自由戰術：</strong>夥伴自動判斷使用所有已學技能</li>
+                            <li><strong>防護戰術：</strong>專注使用防護技能，吸引仇恨</li>
+                            <li><strong>治療戰術：</strong>專注治療，不會自動攻擊</li>
+                            <li><strong>進攻戰術：</strong>專注使用攻擊技能</li>
+                            <li><strong>跟隨/離開：</strong>控制夥伴的跟隨狀態</li>
+                        </ul>
+
+                        <div class="guide-info-card guide-note">
+                            <strong>小知識：</strong>無論選擇何種戰術，已學習的被動技能（如力量提高、精神提高等）都會持續生效。
+                        </div>
+                    </div>
+                </article>
+
+                <!-- Page Navigation -->
+                <nav class="page-nav">
+                    <a href="sightseeing.html" class="page-nav-prev">
+                        ← <span data-i18n="guide_toc_sightseeing">探索筆記</span>
+                    </a>
+                    <span class="page-nav-next"></span>
+                </nav>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <!-- Required JS imports -->
+    <script src="../../assets/js/i18n/i18n-manager.js"></script>
+    <script src="../../assets/js/i18n/translations/common.js"></script>
+    <script src="../../assets/js/i18n/translations/tools/guide.js"></script>
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+    <script src="sidebar-template.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/guide/dungeon.html
+++ b/tools/guide/dungeon.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>副本 - 攻略資料 - FF14.tw</title>
+    <meta name="description" content="FF14 副本系統完整說明，包含四人迷宮、八人討伐、24人聯盟副本與配對系統">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+
+    <!-- Required CSS imports -->
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- Header placeholder -->
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="攻略資料" data-tool-name-key="guide_header"></div>
+
+    <!-- Noscript fallback -->
+    <noscript>
+        <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
+            <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
+            <a href="/copyright.html" style="color: white; margin: 0 1rem;">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" style="color: white; margin: 0 1rem;">GitHub</a>
+            <a href="/about.html" style="color: white; margin: 0 1rem;">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container guide-layout">
+            <!-- Sidebar placeholder -->
+            <div id="guide-sidebar-placeholder" data-current-page="dungeon"></div>
+
+            <!-- Main Content Wrapper -->
+            <div class="guide-content-wrapper">
+                <article class="guide-article">
+                    <h1 class="article-title">
+                        <span class="article-icon">🏰</span>
+                        <span data-i18n="guide_section_dungeon_title">副本</span>
+                    </h1>
+                    <div class="article-content">
+                        <div class="coming-soon">
+                            <p data-i18n="guide_coming_soon">本頁面內容準備中，敬請期待！</p>
+                        </div>
+                    </div>
+                </article>
+
+                <!-- Page Navigation -->
+                <nav class="page-nav">
+                    <a href="grand-company.html" class="page-nav-prev">
+                        ← <span data-i18n="guide_toc_grand_company">大國防聯軍</span>
+                    </a>
+                    <a href="aether.html" class="page-nav-next">
+                        <span data-i18n="guide_toc_aether">風脈</span> →
+                    </a>
+                </nav>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <!-- Required JS imports -->
+    <script src="../../assets/js/i18n/i18n-manager.js"></script>
+    <script src="../../assets/js/i18n/translations/common.js"></script>
+    <script src="../../assets/js/i18n/translations/tools/guide.js"></script>
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+    <script src="sidebar-template.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/guide/grand-company.html
+++ b/tools/guide/grand-company.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>大國防聯軍 - 攻略資料 - FF14.tw</title>
+    <meta name="description" content="FF14 大國防聯軍完整指南，包含三大軍團介紹、軍階系統、軍票獲取、晉升條件與冒險者分隊">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+
+    <!-- Required CSS imports -->
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- Header placeholder -->
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="攻略資料" data-tool-name-key="guide_header"></div>
+
+    <!-- Noscript fallback -->
+    <noscript>
+        <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
+            <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
+            <a href="/copyright.html" style="color: white; margin: 0 1rem;">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" style="color: white; margin: 0 1rem;">GitHub</a>
+            <a href="/about.html" style="color: white; margin: 0 1rem;">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container guide-layout">
+            <!-- Sidebar placeholder -->
+            <div id="guide-sidebar-placeholder" data-current-page="grand-company"></div>
+
+            <!-- Main Content Wrapper -->
+            <div class="guide-content-wrapper">
+                <article class="guide-article">
+                    <h1 class="article-title">
+                        <span class="article-icon">🎖️</span>
+                        <span data-i18n="guide_section_grand_company_title">大國防聯軍</span>
+                    </h1>
+                    <div class="article-content">
+                        <h2>什麼是大國防聯軍</h2>
+                        <p>大國防聯軍（Grand Company）是艾歐澤亞各城邦為因應危機而設立的軍事組織。加入後可獲得軍票、解鎖專屬坐騎，並使用各種軍隊功能。</p>
+                        <p>你可以在角色視窗的個人資訊欄位查看目前的軍階。</p>
+
+                        <h2>加入大國防聯軍</h2>
+                        <p>完成主線任務「英雄之卵」後，可以選擇加入三個大國防聯軍之一：</p>
+                        <ul>
+                            <li><strong>黑渦團：</strong>完成「直至大海吞噬一切」後正式加入</li>
+                            <li><strong>雙蛇黨：</strong>完成「森林的意志給我指引」後正式加入</li>
+                            <li><strong>恆輝隊：</strong>完成「為了財富為了國家」後正式加入</li>
+                        </ul>
+
+                        <div class="guide-info-card guide-note">
+                            <strong>小知識：</strong>三個大國防聯軍之間並非敵對關係，不同軍隊的玩家可以正常組隊、加入同一個部隊（FC）共同遊玩。
+                        </div>
+
+                        <h2>三大軍團介紹</h2>
+
+                        <h3>黑渦團（Maelstrom）</h3>
+                        <p>總部位於海都利姆薩·羅敏薩的黑渦軍令部。由提督梅爾維布·布魯菲斯維因領導，以海盜風格著稱。</p>
+
+                        <h3>雙蛇黨（Order of the Twin Adder）</h3>
+                        <p>總部位於森都格里達尼亞的蛇巢司令部。由黨首嘉恩·艾·神納領導，是森林的守護者。</p>
+
+                        <h3>恆輝隊（Immortal Flames）</h3>
+                        <p>總部位於沙都烏爾達哈的恆輝作戰總部。由總帥勞班·阿爾丁領導，是沙漠中的精銳部隊。</p>
+
+                        <div class="guide-info-card guide-tip">
+                            <strong>提示：</strong>選擇哪個大國防聯軍主要是外觀差異（制服與坐騎樣式），不會影響遊戲進度或角色能力。
+                        </div>
+
+                        <h2>轉換軍團</h2>
+                        <p>軍階達到 9 級（協漩尉／協牙尉／協耀尉）後，可以申請轉換所屬軍團。</p>
+
+                        <h3>轉換規則</h3>
+                        <ul>
+                            <li>每次轉換有 <strong>15 天冷卻時間</strong></li>
+                            <li>第一次轉換免費，之後每次需繳納金幣</li>
+                            <li>轉換後軍階與軍票會歸零重新計算</li>
+                            <li>原軍隊的軍票會被凍結（再轉回時可恢復）</li>
+                            <li>冒險者分隊等級與成員不受影響，但需重新晉升才能使用</li>
+                        </ul>
+
+                        <h3>轉換後的限制</h3>
+                        <ul>
+                            <li>無法裝備非所屬軍隊的裝備</li>
+                            <li>無法使用非所屬軍隊的專用坐騎</li>
+                            <li>無法接受非所屬軍隊的通緝令</li>
+                            <li>無法使用非所屬軍隊的傳送網使用券</li>
+                        </ul>
+
+                        <div class="guide-info-card guide-note">
+                            <strong>好消息：</strong>若你已在某軍隊達到最高軍階後轉隊，日後轉回時軍階會保留。因此玩家可以在三個軍隊都升到最高軍階。
+                        </div>
+
+                        <h2>軍階系統</h2>
+                        <p>軍階是大國防聯軍內的等級制度，三個軍隊的等級結構相同，只是名稱不同。晉升軍階可解鎖更多功能和購買更多物品。</p>
+
+                        <h3>軍階等級一覽</h3>
+                        <p>以下為可晉升的 11 個軍階：</p>
+                        <ul>
+                            <li><strong>1 級（二等兵）：</strong>加入時的初始軍階，軍票上限 10,000</li>
+                            <li><strong>2 級（一等兵）：</strong>繳納 2,000 軍票，上限 15,000</li>
+                            <li><strong>3 級（上等兵）：</strong>繳納 3,000 軍票，上限 20,000</li>
+                            <li><strong>4 級（兵長）：</strong>繳納 4,000 軍票，上限 25,000</li>
+                            <li><strong>5 級（協士）：</strong>完成 1 級軍隊討伐筆記後，繳納 5,000 軍票，上限 30,000</li>
+                            <li><strong>6 級（副士）：</strong>繳納 6,000 軍票，上限 35,000</li>
+                            <li><strong>7 級（正士）：</strong>繳納 7,000 軍票，上限 40,000</li>
+                            <li><strong>8 級（士長）：</strong>完成「來自北方的協助請求」後，繳納 8,000 軍票，上限 45,000</li>
+                            <li><strong>9 級（協尉）：</strong>完成 2 級討伐筆記和「黃金谷掃蕩作戰」後，繳納 9,000 軍票，上限 50,000</li>
+                            <li><strong>10 級（副尉）：</strong>冒險者分隊有隊員達 40 級，完成「重要任務：奪取水晶」，上限 80,000</li>
+                            <li><strong>11 級（正尉）：</strong>完成 5 種分隊攻略任務，完成「重要任務：殲滅帝國軍特殊部隊」，上限 90,000</li>
+                        </ul>
+
+                        <h2>軍票獲取方式</h2>
+                        <p>軍票是大國防聯軍的專屬貨幣，可透過以下方式獲得：</p>
+                        <ul>
+                            <li><strong>隨機任務：</strong>練級、行會令等每日隨機任務</li>
+                            <li><strong>臨危受命（FATE）：</strong>參與野外 FATE 事件</li>
+                            <li><strong>軍隊籌備：</strong>每日繳交製作或採集物品</li>
+                            <li><strong>軍隊討伐筆記：</strong>狩獵指定魔物</li>
+                            <li><strong>軍隊理符：</strong>可重複完成的理符任務</li>
+                            <li><strong>稀有品交付：</strong>繳交綠色、藍色裝備換取軍票</li>
+                        </ul>
+
+                        <h2>軍隊任務</h2>
+
+                        <h3>籌備軍需品與補給品</h3>
+                        <p>每天軍隊會對所有能工巧匠和大地使者職業發布物資需求。可用 Ctrl+U 開啟任務情報查看當日籌備項目。</p>
+                        <ul>
+                            <li>物資等級與玩家對應職業等級相近</li>
+                            <li>繳交後可獲得該職業經驗與軍票</li>
+                            <li>繳交標有星號或 HQ 物品可獲得雙倍獎勵（最高 4 倍）</li>
+                            <li>每天每個職業僅可繳交一次，每日凌晨 4 點（台灣時間）刷新</li>
+                        </ul>
+
+                        <h3>籌備稀有品</h3>
+                        <p>軍階達到 6 級（副士）後開放。可繳交綠色、藍色等稀有裝備換取軍票。</p>
+                        <ul>
+                            <li>裝備品級越高，獲得的軍票越多</li>
+                            <li>可選擇隱藏套裝或兵裝庫中的物品，避免誤交</li>
+                            <li>製作採集裝備等特殊裝備無法繳交</li>
+                        </ul>
+
+                        <div class="guide-info-card guide-tip">
+                            <strong>提示：</strong>不需要的副本掉落裝備可以拿去換軍票，是很好的軍票來源！
+                        </div>
+
+                        <h2>軍票兌換品</h2>
+                        <p>軍票可以在軍隊總部兌換各種實用物品：</p>
+                        <ul>
+                            <li>裝備與武器</li>
+                            <li>專屬坐騎（陸行鳥等）與寵物</li>
+                            <li>冒險者分隊相關物品</li>
+                            <li>素材與消耗品</li>
+                            <li>房屋裝飾品</li>
+                            <li>傳送網使用券</li>
+                        </ul>
+
+                        <h2>冒險者分隊</h2>
+                        <p>軍階達到 9 級（協尉）後解鎖。可將軍隊的 NPC 志願兵編成分隊，派遣執行任務獲得獎勵。</p>
+
+                        <h3>重要晉升任務</h3>
+                        <ul>
+                            <li><strong>奪取水晶：</strong>分隊 40 級任務，完成後可晉升為副尉（10 級）</li>
+                            <li><strong>殲滅帝國軍特殊部隊：</strong>分隊 50 級任務，完成後可晉升為正尉（11 級）</li>
+                        </ul>
+
+                        <div class="guide-info-card guide-tip">
+                            <strong>提示：</strong>善用冒險者分隊可以獲得額外的經驗和道具獎勵，是練等的好幫手！
+                        </div>
+                    </div>
+                </article>
+
+                <!-- Page Navigation -->
+                <nav class="page-nav">
+                    <a href="guild.html" class="page-nav-prev">
+                        ← <span data-i18n="guide_toc_guild">公會</span>
+                    </a>
+                    <a href="dungeon.html" class="page-nav-next">
+                        <span data-i18n="guide_toc_dungeon">副本</span> →
+                    </a>
+                </nav>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <!-- Required JS imports -->
+    <script src="../../assets/js/i18n/i18n-manager.js"></script>
+    <script src="../../assets/js/i18n/translations/common.js"></script>
+    <script src="../../assets/js/i18n/translations/tools/guide.js"></script>
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+    <script src="sidebar-template.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/guide/guild.html
+++ b/tools/guide/guild.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>公會 - 攻略資料 - FF14.tw</title>
+    <meta name="description" content="FF14 部隊（Free Company）公會系統完整說明，包含加入方式、部隊功能與福利">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+
+    <!-- Required CSS imports -->
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- Header placeholder -->
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="攻略資料" data-tool-name-key="guide_header"></div>
+
+    <!-- Noscript fallback -->
+    <noscript>
+        <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
+            <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
+            <a href="/copyright.html" style="color: white; margin: 0 1rem;">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" style="color: white; margin: 0 1rem;">GitHub</a>
+            <a href="/about.html" style="color: white; margin: 0 1rem;">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container guide-layout">
+            <!-- Sidebar placeholder -->
+            <div id="guide-sidebar-placeholder" data-current-page="guild"></div>
+
+            <!-- Main Content Wrapper -->
+            <div class="guide-content-wrapper">
+                <article class="guide-article">
+                    <h1 class="article-title">
+                        <span class="article-icon">🏠</span>
+                        <span data-i18n="guide_section_guild_title">公會</span>
+                    </h1>
+                    <div class="article-content">
+                        <div class="coming-soon">
+                            <p data-i18n="guide_coming_soon">本頁面內容準備中，敬請期待！</p>
+                        </div>
+                    </div>
+                </article>
+
+                <!-- Page Navigation -->
+                <nav class="page-nav">
+                    <span class="page-nav-prev"></span>
+                    <a href="grand-company.html" class="page-nav-next">
+                        <span data-i18n="guide_toc_grand_company">大國防聯軍</span> →
+                    </a>
+                </nav>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <!-- Required JS imports -->
+    <script src="../../assets/js/i18n/i18n-manager.js"></script>
+    <script src="../../assets/js/i18n/translations/common.js"></script>
+    <script src="../../assets/js/i18n/translations/tools/guide.js"></script>
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+    <script src="sidebar-template.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/guide/index.html
+++ b/tools/guide/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>攻略資料 - FF14.tw</title>
+    <meta name="description" content="FF14 新手攻略指南，包含公會系統、軍階、副本、風脈與探索筆記完整說明">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+
+    <!-- Required CSS imports -->
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- Header placeholder -->
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="攻略資料" data-tool-name-key="guide_header"></div>
+
+    <!-- Noscript fallback -->
+    <noscript>
+        <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
+            <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
+            <a href="/copyright.html" style="color: white; margin: 0 1rem;">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" style="color: white; margin: 0 1rem;">GitHub</a>
+            <a href="/about.html" style="color: white; margin: 0 1rem;">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container">
+            <section class="guide-landing">
+                <h1 class="landing-title" data-i18n="guide_header">攻略資料</h1>
+                <p class="landing-subtitle" data-i18n="guide_landing_desc">選擇主題開始閱讀</p>
+
+                <div class="guide-cards-grid">
+                    <a href="guild.html" class="guide-card">
+                        <h2 class="guide-card-title" data-i18n="guide_toc_guild">公會</h2>
+                        <p class="guide-card-desc" data-i18n="guide_guild_desc">部隊系統、加入方式與福利</p>
+                    </a>
+
+                    <a href="grand-company.html" class="guide-card">
+                        <h2 class="guide-card-title" data-i18n="guide_toc_grand_company">大國防聯軍</h2>
+                        <p class="guide-card-desc" data-i18n="guide_grand_company_desc">三大軍團、軍階系統與軍票</p>
+                    </a>
+
+                    <a href="dungeon.html" class="guide-card">
+                        <h2 class="guide-card-title" data-i18n="guide_toc_dungeon">副本</h2>
+                        <p class="guide-card-desc" data-i18n="guide_dungeon_desc">副本類型與開放條件</p>
+                    </a>
+
+                    <a href="aether.html" class="guide-card">
+                        <h2 class="guide-card-title" data-i18n="guide_toc_aether">風脈</h2>
+                        <p class="guide-card-desc" data-i18n="guide_aether_desc">風脈泉解鎖與飛行系統</p>
+                    </a>
+
+                    <a href="sightseeing.html" class="guide-card">
+                        <h2 class="guide-card-title" data-i18n="guide_toc_sightseeing">探索筆記</h2>
+                        <p class="guide-card-desc" data-i18n="guide_sightseeing_desc">探索筆記機制與獎勵</p>
+                    </a>
+
+                    <a href="chocobo.html" class="guide-card">
+                        <h2 class="guide-card-title" data-i18n="guide_toc_chocobo">專屬陸行鳥</h2>
+                        <p class="guide-card-desc" data-i18n="guide_chocobo_desc">陸行鳥夥伴系統與養成指南</p>
+                    </a>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <!-- Required JS imports -->
+    <script src="../../assets/js/i18n/i18n-manager.js"></script>
+    <script src="../../assets/js/i18n/translations/common.js"></script>
+    <script src="../../assets/js/i18n/translations/tools/guide.js"></script>
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+</body>
+</html>

--- a/tools/guide/script.js
+++ b/tools/guide/script.js
@@ -1,0 +1,54 @@
+/**
+ * GuideManager - Controller for Guide sub-pages
+ * Handles sidebar loading and current page highlighting
+ */
+class GuideManager {
+    static CONSTANTS = {
+        SIDEBAR_PLACEHOLDER_ID: 'guide-sidebar-placeholder'
+    };
+
+    /**
+     * Initialize the guide manager
+     */
+    constructor() {
+        this.init();
+    }
+
+    /**
+     * Initialize functionality
+     */
+    init() {
+        this.loadSidebar();
+        this.refreshI18n();
+    }
+
+    /**
+     * Load sidebar template into placeholder
+     */
+    loadSidebar() {
+        if (typeof GuideSidebarTemplate === 'undefined') {
+            console.error('[GuideManager] GuideSidebarTemplate not loaded');
+            return;
+        }
+
+        GuideSidebarTemplate.load(GuideManager.CONSTANTS.SIDEBAR_PLACEHOLDER_ID);
+    }
+
+    /**
+     * Refresh i18n translations after sidebar is loaded
+     */
+    refreshI18n() {
+        // If I18nManager exists and is initialized, update translations
+        if (typeof I18nManager !== 'undefined' && window.i18n) {
+            window.i18n.updatePageLanguage();
+        }
+    }
+}
+
+// Initialize when DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+    // Only initialize on sub-pages with sidebar placeholder
+    if (document.getElementById('guide-sidebar-placeholder')) {
+        window.guideManager = new GuideManager();
+    }
+});

--- a/tools/guide/sidebar-template.js
+++ b/tools/guide/sidebar-template.js
@@ -1,0 +1,106 @@
+/**
+ * Guide Sidebar Template
+ * Creates the sidebar navigation for guide pages using DOM builder pattern
+ */
+const GuideSidebarTemplate = {
+    // Sidebar navigation items configuration
+    ITEMS: [
+        { href: 'guild.html', page: 'guild', icon: '🏠', i18nKey: 'guide_toc_guild', text: '公會' },
+        { href: 'grand-company.html', page: 'grand-company', icon: '🎖️', i18nKey: 'guide_toc_grand_company', text: '大國防聯軍' },
+        { href: 'dungeon.html', page: 'dungeon', icon: '🏰', i18nKey: 'guide_toc_dungeon', text: '副本' },
+        { href: 'aether.html', page: 'aether', icon: '💨', i18nKey: 'guide_toc_aether', text: '風脈' },
+        { href: 'sightseeing.html', page: 'sightseeing', icon: '📔', i18nKey: 'guide_toc_sightseeing', text: '探索筆記' },
+        { href: 'chocobo.html', page: 'chocobo', icon: '🐤', i18nKey: 'guide_toc_chocobo', text: '專屬陸行鳥' }
+    ],
+
+    /**
+     * Create sidebar DOM structure
+     * @param {Object} options - Configuration options
+     * @param {string} options.currentPage - Current page identifier for active state
+     * @returns {HTMLElement} Complete sidebar aside element
+     */
+    createDOM(options = {}) {
+        const { currentPage = '' } = options;
+
+        // Create main aside container
+        const aside = document.createElement('aside');
+        aside.className = 'toc-sidebar';
+
+        // Create inner container
+        const container = document.createElement('div');
+        container.className = 'toc-container';
+
+        // Create title
+        const title = document.createElement('h2');
+        title.className = 'toc-title';
+        title.setAttribute('data-i18n', 'guide_toc_title');
+        title.textContent = '目錄';
+        container.appendChild(title);
+
+        // Create navigation
+        const nav = document.createElement('nav');
+        nav.className = 'toc-nav';
+        nav.id = 'tocNav';
+
+        // Create navigation links
+        this.ITEMS.forEach(item => {
+            const link = document.createElement('a');
+            link.href = item.href;
+            link.className = 'toc-link';
+            if (item.page === currentPage) {
+                link.classList.add('active');
+            }
+            link.setAttribute('data-page', item.page);
+
+            // Create icon span
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'toc-icon';
+            iconSpan.textContent = item.icon;
+            link.appendChild(iconSpan);
+
+            // Create text span with i18n
+            const textSpan = document.createElement('span');
+            textSpan.setAttribute('data-i18n', item.i18nKey);
+            textSpan.textContent = item.text;
+            link.appendChild(textSpan);
+
+            nav.appendChild(link);
+        });
+
+        container.appendChild(nav);
+
+        // Create back to index link
+        const backLink = document.createElement('a');
+        backLink.href = 'index.html';
+        backLink.className = 'back-to-landing';
+        backLink.setAttribute('data-i18n', 'guide_back_to_index');
+        backLink.textContent = '← 返回總覽';
+        container.appendChild(backLink);
+
+        aside.appendChild(container);
+
+        return aside;
+    },
+
+    /**
+     * Load sidebar into placeholder element
+     * @param {string} placeholderId - ID of placeholder element
+     * @returns {HTMLElement|null} Created sidebar element or null if placeholder not found
+     */
+    load(placeholderId = 'guide-sidebar-placeholder') {
+        const placeholder = document.getElementById(placeholderId);
+        if (!placeholder) {
+            return null;
+        }
+
+        const currentPage = placeholder.dataset.currentPage || '';
+        const sidebar = this.createDOM({ currentPage });
+
+        placeholder.replaceWith(sidebar);
+
+        return sidebar;
+    }
+};
+
+// Export globally
+window.GuideSidebarTemplate = GuideSidebarTemplate;

--- a/tools/guide/sightseeing.html
+++ b/tools/guide/sightseeing.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>探索筆記 - 攻略資料 - FF14.tw</title>
+    <meta name="description" content="FF14 探索筆記系統完整說明，包含景點收集、完成技巧與獎勵">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+
+    <!-- Required CSS imports -->
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- Header placeholder -->
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="攻略資料" data-tool-name-key="guide_header"></div>
+
+    <!-- Noscript fallback -->
+    <noscript>
+        <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
+            <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
+            <a href="/copyright.html" style="color: white; margin: 0 1rem;">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" style="color: white; margin: 0 1rem;">GitHub</a>
+            <a href="/about.html" style="color: white; margin: 0 1rem;">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container guide-layout">
+            <!-- Sidebar placeholder -->
+            <div id="guide-sidebar-placeholder" data-current-page="sightseeing"></div>
+
+            <!-- Main Content Wrapper -->
+            <div class="guide-content-wrapper">
+                <article class="guide-article">
+                    <h1 class="article-title">
+                        <span class="article-icon">📔</span>
+                        <span data-i18n="guide_section_sightseeing_title">探索筆記</span>
+                    </h1>
+                    <div class="article-content">
+                        <div class="coming-soon">
+                            <p data-i18n="guide_coming_soon">本頁面內容準備中，敬請期待！</p>
+                        </div>
+                    </div>
+                </article>
+
+                <!-- Page Navigation -->
+                <nav class="page-nav">
+                    <a href="aether.html" class="page-nav-prev">
+                        ← <span data-i18n="guide_toc_aether">風脈</span>
+                    </a>
+                    <a href="chocobo.html" class="page-nav-next">
+                        <span data-i18n="guide_toc_chocobo">專屬陸行鳥</span> →
+                    </a>
+                </nav>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <!-- Required JS imports -->
+    <script src="../../assets/js/i18n/i18n-manager.js"></script>
+    <script src="../../assets/js/i18n/translations/common.js"></script>
+    <script src="../../assets/js/i18n/translations/tools/guide.js"></script>
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+    <script src="sidebar-template.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/guide/style.css
+++ b/tools/guide/style.css
@@ -1,0 +1,806 @@
+/* Guide Tool Styles */
+
+/* ==========================================================================
+   Landing Page
+   ========================================================================== */
+
+.guide-landing {
+    text-align: center;
+    padding: 3rem 0;
+}
+
+.landing-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    margin: 0 0 1rem 0;
+}
+
+.landing-subtitle {
+    font-size: 1.2rem;
+    color: var(--text-secondary, #666);
+    margin: 0 0 3rem 0;
+}
+
+.guide-cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.guide-card {
+    background: var(--card-bg, white);
+    border-radius: var(--border-radius-lg, 12px);
+    padding: 2rem;
+    text-decoration: none;
+    color: inherit;
+    box-shadow: var(--shadow);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    border: 2px solid transparent;
+}
+
+.guide-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+    border-color: var(--primary-color);
+}
+
+.guide-card-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.guide-card-title {
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: var(--dark-color, #333);
+    margin: 0 0 0.75rem 0;
+}
+
+.guide-card-desc {
+    font-size: 0.95rem;
+    color: var(--text-secondary, #666);
+    margin: 0;
+    line-height: 1.6;
+}
+
+/* Dark mode landing page */
+[data-theme="dark"] .guide-card {
+    background: var(--card-bg);
+}
+
+[data-theme="dark"] .guide-card:hover {
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .guide-card-title {
+    color: var(--text-color);
+}
+
+[data-theme="dark"] .guide-card-desc {
+    color: var(--text-secondary);
+}
+
+/* ==========================================================================
+   Layout System
+   ========================================================================== */
+
+.guide-layout {
+    display: flex;
+    gap: 3rem;
+    align-items: flex-start;
+    position: relative;
+    padding: 2rem 0;
+}
+
+.guide-content-wrapper {
+    flex: 1;
+    min-width: 0;
+    max-width: 900px;
+}
+
+/* ==========================================================================
+   Sticky TOC Sidebar
+   ========================================================================== */
+
+.toc-sidebar {
+    position: sticky;
+    top: 2rem;
+    width: 280px;
+    flex-shrink: 0;
+    max-height: calc(100vh - 4rem);
+    overflow-y: auto;
+}
+
+.toc-container {
+    background: var(--card-bg, white);
+    border-radius: var(--border-radius-lg, 12px);
+    padding: 1.5rem;
+    box-shadow: var(--shadow);
+}
+
+/* ==========================================================================
+   Search Box
+   ========================================================================== */
+
+.guide-search {
+    margin-bottom: 1.5rem;
+}
+
+.guide-search .form-control {
+    font-size: 0.9rem;
+    padding: 0.6rem 1rem;
+    border-radius: var(--border-radius, 8px);
+}
+
+.guide-search .form-control:focus {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.15);
+}
+
+.search-results-info {
+    display: none;
+    margin-top: 1rem;
+    padding: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    text-align: center;
+    background: var(--gray-100, #f5f5f5);
+    border-radius: var(--border-radius-sm, 6px);
+}
+
+.search-results-info.visible {
+    display: block;
+}
+
+/* ==========================================================================
+   TOC Navigation
+   ========================================================================== */
+
+.toc-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--primary-color);
+    margin: 0 0 1rem 0;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--primary-color);
+}
+
+.toc-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.toc-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-color);
+    text-decoration: none;
+    padding: 0.6rem 0.75rem;
+    border-radius: var(--border-radius-sm, 6px);
+    transition: all 0.2s ease;
+    font-size: 0.95rem;
+    border-left: 3px solid transparent;
+}
+
+.toc-link:hover {
+    background: var(--gray-100, #f5f5f5);
+    color: var(--primary-color);
+}
+
+.toc-link.active {
+    background: var(--primary-color);
+    color: white;
+    border-left-color: transparent;
+}
+
+.toc-icon {
+    font-size: 1.1rem;
+    width: 1.5rem;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+/* Search match states for TOC */
+.toc-link.has-match {
+    background: rgba(74, 144, 226, 0.1);
+    border-left-color: var(--primary-color);
+}
+
+.toc-link.no-match {
+    opacity: 0.4;
+}
+
+/* Back to landing link */
+.back-to-landing {
+    display: block;
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color, #e0e0e0);
+    color: var(--text-secondary, #666);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: color 0.2s ease;
+}
+
+.back-to-landing:hover {
+    color: var(--primary-color);
+}
+
+/* TOC Scrollbar */
+.toc-sidebar::-webkit-scrollbar {
+    width: 6px;
+}
+
+.toc-sidebar::-webkit-scrollbar-track {
+    background: var(--gray-100, #f1f1f1);
+    border-radius: 3px;
+}
+
+.toc-sidebar::-webkit-scrollbar-thumb {
+    background: var(--gray-400, #888);
+    border-radius: 3px;
+}
+
+.toc-sidebar::-webkit-scrollbar-thumb:hover {
+    background: var(--gray-600, #555);
+}
+
+/* ==========================================================================
+   Guide Sections
+   ========================================================================== */
+
+.guide-section {
+    background: var(--card-bg, white);
+    border-radius: var(--border-radius-lg, 12px);
+    padding: 2.5rem;
+    margin-bottom: 2rem;
+    box-shadow: var(--shadow);
+    scroll-margin-top: 2rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.guide-section:last-child {
+    margin-bottom: 0;
+}
+
+.guide-section:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+/* Section Title */
+.section-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: var(--primary-color);
+    margin: 0 0 1.5rem 0;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid var(--border-color, #e0e0e0);
+}
+
+.section-icon {
+    font-size: 1.4rem;
+}
+
+/* Section Content - Optimized for reading */
+.section-content {
+    line-height: 1.8;
+    color: var(--text-color);
+}
+
+.section-content h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--dark-color, #333);
+    margin: 2rem 0 1rem;
+}
+
+.section-content h3:first-child {
+    margin-top: 0;
+}
+
+.section-content h4 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-color);
+    margin: 1.5rem 0 0.75rem;
+}
+
+.section-content p {
+    margin-bottom: 1.25rem;
+    text-align: justify;
+}
+
+.section-content ul,
+.section-content ol {
+    margin: 1rem 0;
+    padding-left: 1.5rem;
+}
+
+.section-content li {
+    margin-bottom: 0.5rem;
+}
+
+.section-content li strong {
+    color: var(--primary-color);
+}
+
+/* Search hidden state */
+.guide-section.search-hidden {
+    display: none;
+}
+
+/* Search highlight */
+.search-highlight {
+    background: linear-gradient(180deg, transparent 50%, rgba(74, 144, 226, 0.3) 50%);
+    padding: 0 2px;
+    border-radius: 2px;
+}
+
+/* ==========================================================================
+   Article Styles (Sub-pages)
+   ========================================================================== */
+
+.guide-article {
+    background: var(--card-bg, white);
+    border-radius: var(--border-radius-lg, 12px);
+    padding: 2.5rem;
+    box-shadow: var(--shadow);
+}
+
+.article-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    margin: 0 0 2rem 0;
+    padding-bottom: 1rem;
+    border-bottom: 3px solid var(--primary-color);
+}
+
+.article-icon {
+    font-size: 1.8rem;
+}
+
+.article-content {
+    line-height: 1.8;
+    color: var(--text-color);
+}
+
+.article-content h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--dark-color, #333);
+    margin: 2.5rem 0 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--border-color, #e0e0e0);
+}
+
+.article-content h2:first-child {
+    margin-top: 0;
+}
+
+.article-content h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--dark-color, #333);
+    margin: 2rem 0 1rem;
+}
+
+.article-content h4 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-color);
+    margin: 1.5rem 0 0.75rem;
+}
+
+.article-content p {
+    margin-bottom: 1.25rem;
+    text-align: justify;
+}
+
+.article-content ul,
+.article-content ol {
+    margin: 1rem 0;
+    padding-left: 1.5rem;
+}
+
+.article-content li {
+    margin-bottom: 0.5rem;
+}
+
+.article-content li strong {
+    color: var(--primary-color);
+}
+
+/* ==========================================================================
+   Coming Soon
+   ========================================================================== */
+
+.coming-soon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 200px;
+    text-align: center;
+}
+
+.coming-soon p {
+    font-size: 1.25rem;
+    color: var(--text-secondary, #666);
+    margin: 0;
+    padding: 2rem;
+    background: var(--gray-50, #f9fafb);
+    border-radius: var(--border-radius-lg, 12px);
+    border: 2px dashed var(--border-color, #e0e0e0);
+}
+
+[data-theme="dark"] .coming-soon p {
+    background: var(--bg-secondary, #252836);
+    border-color: var(--border-color);
+    color: var(--text-secondary);
+}
+
+/* Dark mode article */
+[data-theme="dark"] .guide-article {
+    background: var(--card-bg);
+}
+
+[data-theme="dark"] .article-content h2,
+[data-theme="dark"] .article-content h3 {
+    color: var(--text-color);
+}
+
+/* ==========================================================================
+   Page Navigation
+   ========================================================================== */
+
+.page-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 2rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border-color, #e0e0e0);
+}
+
+.page-nav-prev,
+.page-nav-next {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    background: var(--card-bg, white);
+    border-radius: var(--border-radius, 8px);
+    color: var(--primary-color);
+    text-decoration: none;
+    font-weight: 500;
+    box-shadow: var(--shadow);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.page-nav-prev:hover,
+.page-nav-next:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+}
+
+.page-nav-prev:empty,
+.page-nav-next:empty {
+    visibility: hidden;
+}
+
+/* Dark mode page nav */
+[data-theme="dark"] .page-nav-prev,
+[data-theme="dark"] .page-nav-next {
+    background: var(--card-bg);
+}
+
+[data-theme="dark"] .page-nav-prev:hover,
+[data-theme="dark"] .page-nav-next:hover {
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+}
+
+/* ==========================================================================
+   Info Cards
+   ========================================================================== */
+
+.guide-info-card {
+    background: var(--gray-50, #f9fafb);
+    border-radius: var(--border-radius, 8px);
+    padding: 1.25rem;
+    margin: 1.5rem 0;
+    border-left: 4px solid var(--primary-color);
+}
+
+.guide-info-card strong {
+    color: inherit;
+}
+
+.guide-tip {
+    background: linear-gradient(135deg, #e8f5e9 0%, #c8e6c9 100%);
+    border-left-color: #4caf50;
+}
+
+.guide-tip strong {
+    color: #2e7d32;
+}
+
+.guide-warning {
+    background: linear-gradient(135deg, #fff3e0 0%, #ffe0b2 100%);
+    border-left-color: #ff9800;
+}
+
+.guide-warning strong {
+    color: #e65100;
+}
+
+.guide-note {
+    background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
+    border-left-color: var(--primary-color);
+}
+
+.guide-note strong {
+    color: #1565c0;
+}
+
+/* ==========================================================================
+   Dark Mode
+   ========================================================================== */
+
+[data-theme="dark"] .toc-container {
+    background: var(--card-bg);
+}
+
+[data-theme="dark"] .toc-link:hover {
+    background: var(--hover-bg, rgba(255, 255, 255, 0.1));
+}
+
+[data-theme="dark"] .guide-section {
+    background: var(--card-bg);
+}
+
+[data-theme="dark"] .guide-section:hover {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .search-results-info {
+    background: var(--bg-secondary, #252836);
+}
+
+[data-theme="dark"] .search-highlight {
+    background: linear-gradient(180deg, transparent 50%, rgba(90, 159, 240, 0.3) 50%);
+}
+
+[data-theme="dark"] .section-content h3 {
+    color: var(--text-color);
+}
+
+/* Dark mode info cards */
+[data-theme="dark"] .guide-info-card {
+    background: var(--bg-secondary, #252836);
+}
+
+[data-theme="dark"] .guide-tip {
+    background: linear-gradient(135deg, #1b3d1b 0%, #2d4d2d 100%);
+}
+
+[data-theme="dark"] .guide-tip strong {
+    color: #81c784;
+}
+
+[data-theme="dark"] .guide-warning {
+    background: linear-gradient(135deg, #3d2e00 0%, #4d3b00 100%);
+}
+
+[data-theme="dark"] .guide-warning strong {
+    color: #ffb74d;
+}
+
+[data-theme="dark"] .guide-note {
+    background: linear-gradient(135deg, #1a2d3d 0%, #2a3d4d 100%);
+}
+
+[data-theme="dark"] .guide-note strong {
+    color: #64b5f6;
+}
+
+/* ==========================================================================
+   Responsive Design
+   ========================================================================== */
+
+/* Tablet */
+@media (max-width: 1024px) {
+    .landing-title {
+        font-size: 2rem;
+    }
+
+    .guide-cards-grid {
+        gap: 1.5rem;
+    }
+
+    .toc-sidebar {
+        width: 220px;
+    }
+
+    .guide-layout {
+        gap: 2rem;
+    }
+
+    .guide-section {
+        padding: 2rem;
+    }
+
+    .guide-article {
+        padding: 2rem;
+    }
+
+    .article-title {
+        font-size: 1.75rem;
+    }
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+    .landing-title {
+        font-size: 1.8rem;
+    }
+
+    .landing-subtitle {
+        font-size: 1rem;
+        margin-bottom: 2rem;
+    }
+
+    .guide-cards-grid {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+
+    .guide-card {
+        padding: 1.5rem;
+    }
+
+    .guide-card-icon {
+        font-size: 2.5rem;
+    }
+
+    .guide-card-title {
+        font-size: 1.2rem;
+    }
+
+    .guide-layout {
+        flex-direction: column;
+    }
+
+    .toc-sidebar {
+        position: relative;
+        top: 0;
+        width: 100%;
+        max-height: none;
+        margin-bottom: 2rem;
+    }
+
+    .toc-container {
+        max-height: 350px;
+        overflow-y: auto;
+    }
+
+    .guide-section {
+        padding: 1.5rem;
+    }
+
+    .section-title {
+        font-size: 1.4rem;
+    }
+
+    .section-content h3 {
+        font-size: 1.15rem;
+    }
+
+    .guide-article {
+        padding: 1.5rem;
+    }
+
+    .article-title {
+        font-size: 1.5rem;
+    }
+
+    .article-content h2 {
+        font-size: 1.3rem;
+    }
+
+    .page-nav {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .page-nav-prev,
+    .page-nav-next {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
+/* Small Mobile */
+@media (max-width: 480px) {
+    .guide-landing {
+        padding: 2rem 0;
+    }
+
+    .landing-title {
+        font-size: 1.5rem;
+    }
+
+    .guide-card {
+        padding: 1.25rem;
+    }
+
+    .guide-section {
+        padding: 1.25rem;
+        border-radius: var(--border-radius, 8px);
+    }
+
+    .section-title {
+        font-size: 1.25rem;
+        flex-wrap: wrap;
+    }
+
+    .toc-container {
+        padding: 1rem;
+    }
+
+    .toc-link {
+        padding: 0.5rem 0.6rem;
+        font-size: 0.9rem;
+    }
+
+    .guide-info-card {
+        padding: 1rem;
+    }
+
+    .guide-article {
+        padding: 1.25rem;
+        border-radius: var(--border-radius, 8px);
+    }
+
+    .article-title {
+        font-size: 1.3rem;
+        flex-wrap: wrap;
+    }
+
+    .page-nav-prev,
+    .page-nav-next {
+        padding: 0.6rem 1rem;
+        font-size: 0.9rem;
+    }
+}
+
+/* ==========================================================================
+   Print Styles
+   ========================================================================== */
+
+@media print {
+    .toc-sidebar {
+        display: none;
+    }
+
+    .guide-layout {
+        display: block;
+    }
+
+    .guide-section {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #ddd;
+    }
+}


### PR DESCRIPTION
## Summary
- 新增攻略資料工具 (`tools/guide/`)，提供 FF14 新手指南
- 包含 6 個主題頁面：公會、大國防聯軍、副本、風脈、探索筆記、專屬陸行鳥
- 完整的大國防聯軍頁面內容（三大軍團、軍階系統、軍票獲取等）
- 完整的專屬陸行鳥頁面內容（解鎖條件、戰鬥系統、染色指南等）
- 其他 4 個頁面暫時顯示「準備中」狀態
- 支援 i18n 多語系（zh/en/ja）
- 響應式設計與 Dark Mode 支援

## Test plan
- [ ] 確認首頁可正常連結到攻略資料工具
- [ ] 確認各頁面間的導航功能正常
- [ ] 確認側邊欄 active 狀態正確顯示
- [ ] 確認「準備中」頁面正確顯示提示訊息
- [ ] 確認 Dark Mode 樣式正確
- [ ] 確認手機版 RWD 正常顯示
- [ ] 確認語言切換功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)