### PR TITLE
feat: 將 Mini Cactpot 計算機更名為仙人微彩計算機

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Tools that fetch JSON data require a local server:
 - 特殊採集時間管理器 (`timed-gathering/`) - loads `/data/timed-gathering.json`
 
 Tools that work without server (can open HTML directly):
-- Mini Cactpot 計算機
+- 仙人微彩計算機
 - Wondrous Tails 預測器
 - 角色卡產生器
 - Faux Hollows Foxes 計算機

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - 鍵盤導航支援
 - 資料來源：灰機Wiki
 
-### Mini Cactpot 計算機 (`mini-cactpot/`)
+### 仙人微彩計算機 (`mini-cactpot/`)
 - 期望值計算
 - 最佳策略推薦
 - 機率分析
@@ -91,7 +91,7 @@ http://localhost:8000
 - 特殊採集時間管理器 (`timed-gathering/`) - 載入 `/data/timed-gathering.json`
 
 **可直接開啟的工具：**
-- Mini Cactpot 計算機
+- 仙人微彩計算機
 - Wondrous Tails 預測器
 - 角色卡產生器
 - Faux Hollows Foxes 計算機
@@ -146,7 +146,7 @@ ff14.tw/
     ├── dungeon-database/   # 副本資料庫
     ├── faux-hollows-foxes/ # Faux Hollows Foxes 計算機
     ├── lodestone-lookup/   # Lodestone 角色查詢
-    ├── mini-cactpot/       # Mini Cactpot 計算機
+    ├── mini-cactpot/       # 仙人微彩計算機
     ├── timed-gathering/    # 特殊採集時間管理器
     ├── treasure-map-finder/# 寶圖搜尋器
     └── wondrous-tails/     # Wondrous Tails 預測器

--- a/assets/js/i18n/translations/index.js
+++ b/assets/js/i18n/translations/index.js
@@ -12,8 +12,8 @@ const IndexTranslations = {
         hero_subtitle: '提供各種FF14相關的實用工具，讓你的艾歐澤亞冒險更加便利！',
 
         // 工具卡片
-        tool_mini_cactpot_title: 'Mini Cactpot 計算機',
-        tool_mini_cactpot_desc: '分析 Mini Cactpot 最佳策略，計算期望值並推薦最佳線條選擇',
+        tool_mini_cactpot_title: '仙人微彩計算機',
+        tool_mini_cactpot_desc: '分析仙人微彩最佳策略，計算期望值並推薦最佳線條選擇',
 
         tool_wondrous_tails_title: 'Wondrous Tails 預測器',
         tool_wondrous_tails_desc: '分析天書奇談盤面，計算連線成功機率，協助決策是否重置',

--- a/assets/js/i18n/translations/tools/mini-cactpot.js
+++ b/assets/js/i18n/translations/tools/mini-cactpot.js
@@ -1,14 +1,14 @@
 /**
- * FF14.tw Mini Cactpot 計算機翻譯檔
+ * FF14.tw 仙人微彩計算機翻譯檔
  */
 const MiniCactpotTranslations = {
     zh: {
         // 頁面資訊
-        mini_cactpot_title: 'Mini Cactpot 計算機 - FF14.tw',
-        mini_cactpot_description: 'FF14 Mini Cactpot 最佳策略計算工具，分析期望值並推薦最佳選擇',
+        mini_cactpot_title: '仙人微彩計算機 - FF14.tw',
+        mini_cactpot_description: 'FF14 仙人微彩最佳策略計算工具，分析期望值並推薦最佳選擇',
 
         // 頁面標題
-        mini_cactpot_header: 'Mini Cactpot 計算機',
+        mini_cactpot_header: '仙人微彩計算機',
         mini_cactpot_desc: '點選四個格子並輸入對應數字 (1-9)，期望值將自動顯示在對應位置並推薦最佳線條',
 
         // 格子資訊

--- a/changelog.html
+++ b/changelog.html
@@ -1427,7 +1427,7 @@
                         </div>
                         <div class="changelog-content">
                             <ul>
-                                <li><span class="tag tag-success">新增</span> Mini Cactpot 計算機「回到上一步」功能</li>
+                                <li><span class="tag tag-success">新增</span> 仙人微彩計算機「回到上一步」功能</li>
                                 <li><span class="tag tag-infod">改進</span> 支援撤銷選擇格子、取消選擇和輸入數字等操作</li>
                             </ul>
                         </div>
@@ -1440,7 +1440,7 @@
                         </div>
                         <div class="changelog-content">
                             <ul>
-                                <li><span class="tag tag-infod">改進</span> Mini Cactpot 計算機支援填寫四格數字</li>
+                                <li><span class="tag tag-infod">改進</span> 仙人微彩計算機支援填寫四格數字</li>
                                 <li><span class="tag tag-infod">改進</span> 提供更精確的期望值計算結果</li>
                             </ul>
                         </div>
@@ -1725,7 +1725,7 @@
                             <ul>
                                 <li><span class="tag tag-success">新增</span> 副本資料庫 (362個副本)</li>
                                 <li><span class="tag tag-success">新增</span> Wondrous Tails 預測器</li>
-                                <li><span class="tag tag-success">新增</span> Mini Cactpot 計算機</li>
+                                <li><span class="tag tag-success">新增</span> 仙人微彩計算機</li>
                                 <li><span class="tag tag-success">新增</span> 關於/版權頁面</li>
                                 <li><span class="tag tag-info">資訊</span> 資料來源：灰機Wiki</li>
                             </ul>

--- a/index.html
+++ b/index.html
@@ -318,8 +318,8 @@
                 <div class="tools-grid">
                     <a href="tools/mini-cactpot/index.html" class="tool-card available">
                         <div class="tool-icon">🎰</div>
-                        <h3 class="tool-title" data-i18n="tool_mini_cactpot_title">Mini Cactpot 計算機</h3>
-                        <p class="tool-description" data-i18n="tool_mini_cactpot_desc">分析 Mini Cactpot 最佳策略，計算期望值並推薦最佳線條選擇</p>
+                        <h3 class="tool-title" data-i18n="tool_mini_cactpot_title">仙人微彩計算機</h3>
+                        <p class="tool-description" data-i18n="tool_mini_cactpot_desc">分析仙人微彩最佳策略，計算期望值並推薦最佳線條選擇</p>
                     </a>
 
                     <a href="tools/wondrous-tails/index.html" class="tool-card available">

--- a/tools/mini-cactpot/index.html
+++ b/tools/mini-cactpot/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mini Cactpot 計算機 - FF14.tw</title>
-    <meta name="description" content="FF14 Mini Cactpot 最佳策略計算工具，分析期望值並推薦最佳選擇">
+    <title>仙人微彩計算機 - FF14.tw</title>
+    <meta name="description" content="FF14 仙人微彩最佳策略計算工具，分析期望值並推薦最佳選擇">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="header-placeholder" data-base-path="../../" data-tool-name="Mini Cactpot 計算機" data-tool-name-key="mini_cactpot_header"></div>
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="仙人微彩計算機" data-tool-name-key="mini_cactpot_header"></div>
     <noscript>
         <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
             <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
@@ -26,7 +26,7 @@
     <main class="main">
         <div class="container">
             <div class="page-header">
-                <h1 class="visually-hidden" data-i18n="mini_cactpot_header">Mini Cactpot 計算機</h1>
+                <h1 class="visually-hidden" data-i18n="mini_cactpot_header">仙人微彩計算機</h1>
                 <p class="description" data-i18n="mini_cactpot_desc">點選四個格子並輸入對應數字 (1-9)，期望值將自動顯示在對應位置並推薦最佳線條</p>
             </div>
 


### PR DESCRIPTION
## Summary
- 將 Mini Cactpot 計算機的繁體中文名稱更新為「仙人微彩計算機」
- 更新相關的 HTML、i18n 翻譯檔、文件與歷史記錄
- 英文和日文名稱保持不變

## 修改檔案
- `tools/mini-cactpot/index.html` - 工具頁面標題與 meta
- `assets/js/i18n/translations/tools/mini-cactpot.js` - 中文翻譯
- `assets/js/i18n/translations/index.js` - 首頁中文翻譯
- `index.html` - 首頁工具卡片
- `README.md` - 文件說明
- `CLAUDE.md` - 開發文件
- `changelog.html` - 歷史記錄

## Test plan
- [ ] 開啟首頁確認工具卡片顯示「仙人微彩計算機」
- [ ] 開啟仙人微彩計算機頁面確認標題正確
- [ ] 切換至英文確認顯示「Mini Cactpot Calculator」
- [ ] 切換至日文確認顯示「ミニくじテンダー計算機」

🤖 Generated with [Claude Code](https://claude.com/claude-code)