### PR TITLE
feat: 新增檢舉模板產生器

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -39,6 +39,23 @@
                 <p class="subtitle" data-i18n="changelog_hero_subtitle">記錄 FF14.tw 的功能更新與改進</p>
 
                 <div class="changelog-container">
+                <!-- 2025年12月 -->
+                <section class="changelog-section">
+                    <h2 class="changelog-year">2025年12月</h2>
+
+                    <article class="changelog-entry">
+                        <div class="changelog-header">
+                            <h3 class="changelog-version">v2.8.0</h3>
+                            <time class="changelog-date" datetime="2025-12-04">2025年12月4日</time>
+                        </div>
+                        <div class="changelog-content">
+                            <ul>
+                                <li><span class="tag tag-success">新增</span> 檢舉模板產生器：快速產生不當行為檢舉的模板文字</li>
+                            </ul>
+                        </div>
+                    </article>
+                </section>
+
                 <!-- 2025年11月 -->
                 <section class="changelog-section">
                     <h2 class="changelog-year">2025年11月</h2>

--- a/index.html
+++ b/index.html
@@ -374,6 +374,12 @@
                         <p class="tool-description" data-i18n="tool_guide_desc">FF14 新手攻略指南，包含公會、軍階、副本、風脈與探索筆記說明</p>
                     </a>
 
+                    <a href="tools/report-generator/index.html" class="tool-card available">
+                        <div class="tool-icon">📝</div>
+                        <h3 class="tool-title" data-i18n="tool_report_generator_title">檢舉模板產生器</h3>
+                        <p class="tool-description" data-i18n="tool_report_generator_desc">快速產生不當行為檢舉的模板文字，協助您進行申訴</p>
+                    </a>
+
                     <div class="tool-card coming-soon">
                         <span class="status-badge coming-soon" data-i18n="status_coming_soon">即將推出</span>
                         <div class="tool-icon">⚔️</div>

--- a/tools/report-generator/index.html
+++ b/tools/report-generator/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>檢舉模板產生器 - FF14.tw</title>
+    <meta name="description" content="快速產生 FF14 繁中版不當行為檢舉的模板文字，協助玩家進行申訴">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="FF14.tw | 檢舉模板產生器"></div>
+    <noscript>
+        <nav class="noscript-nav">
+            <a href="/" class="noscript-nav-link">首頁</a>
+            <a href="/copyright.html" class="noscript-nav-link">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" class="noscript-nav-link">GitHub</a>
+            <a href="/about.html" class="noscript-nav-link">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container">
+            <div class="page-header">
+                <p class="description">快速產生不當行為檢舉的模板文字，協助您進行申訴</p>
+            </div>
+
+            <div class="tool-content">
+                <form id="reportForm" class="report-form">
+                    <!-- 發生日期 -->
+                    <div class="form-group">
+                        <label for="incidentDate" class="form-label">發生日期 <span class="required">*</span></label>
+                        <input type="date" id="incidentDate" class="form-control" required>
+                    </div>
+
+                    <!-- 時間範圍 -->
+                    <div class="form-group">
+                        <fieldset>
+                            <legend class="form-label">發生時間（選填）</legend>
+                            <div class="time-range">
+                                <label for="timeStart" class="visually-hidden">開始時間</label>
+                                <input type="time" id="timeStart" class="form-control time-input">
+                                <span class="time-separator">~</span>
+                                <label for="timeEnd" class="visually-hidden">結束時間</label>
+                                <input type="time" id="timeEnd" class="form-control time-input">
+                            </div>
+                            <small class="form-text">若不記得確切時間可留空</small>
+                        </fieldset>
+                    </div>
+
+                    <!-- 被檢舉玩家名稱 -->
+                    <div class="form-group">
+                        <label for="playerName" class="form-label">被檢舉玩家名稱 <span class="required">*</span></label>
+                        <input type="text" id="playerName" class="form-control" placeholder="請輸入玩家名稱" required>
+                    </div>
+
+                    <!-- 被檢舉玩家所屬伺服器 -->
+                    <div class="form-group">
+                        <label for="serverSelect" id="serverLabel" class="form-label">被檢舉玩家所屬伺服器 <span class="required">*</span></label>
+                        <select id="serverSelect" class="form-control" required>
+                            <option value="">請選擇伺服器...</option>
+                            <option value="伊弗利特">伊弗利特</option>
+                            <option value="迦樓羅">迦樓羅</option>
+                            <option value="利維坦">利維坦</option>
+                            <option value="鳳凰">鳳凰</option>
+                            <option value="奧汀">奧汀</option>
+                            <option value="巴哈姆特">巴哈姆特</option>
+                            <option value="other">其他</option>
+                        </select>
+                        <input type="text" id="serverCustom" class="form-control custom-input hidden" placeholder="請輸入伺服器名稱" aria-labelledby="serverLabel">
+                    </div>
+
+                    <!-- 事件發生地點 -->
+                    <div class="form-group">
+                        <label for="location" class="form-label">事件發生地點（地圖/副本名稱）<span class="required">*</span></label>
+                        <input type="text" id="location" class="form-control" placeholder="例如：紅蓮決戰阿拉米格、烏爾達哈" required>
+                    </div>
+
+                    <!-- 事件類別 -->
+                    <div class="form-group">
+                        <label for="incidentType" id="incidentTypeLabel" class="form-label">事件類別 <span class="required">*</span></label>
+                        <select id="incidentType" class="form-control" required>
+                            <option value="">請選擇事件類別...</option>
+                            <option value="強迫玩家跳劇情">強迫玩家跳劇情</option>
+                            <option value="違反規範的 ID 名稱">違反規範的 ID 名稱</option>
+                            <option value="違反規範的名片內容">違反規範的名片內容</option>
+                            <option value="惡意 BM">惡意 BM</option>
+                            <option value="破壞遊戲體驗">破壞遊戲體驗</option>
+                            <option value="other">其他</option>
+                        </select>
+                        <input type="text" id="incidentTypeCustom" class="form-control custom-input hidden" placeholder="請輸入事件類別" aria-labelledby="incidentTypeLabel">
+                    </div>
+
+                    <!-- 事件細節 -->
+                    <div class="form-group">
+                        <label for="details" class="form-label">事件細節 <span class="required">*</span></label>
+                        <textarea id="details" class="form-control" rows="6" placeholder="請詳細描述事件經過，包含對方的言行舉止、造成的影響等" required></textarea>
+                        <small class="form-text">請盡可能詳細描述，有助於官方審核</small>
+                    </div>
+
+                    <!-- 按鈕區 -->
+                    <div class="button-group">
+                        <button type="submit" class="btn btn-primary btn-lg">產生模板</button>
+                        <button type="button" id="resetBtn" class="btn btn-secondary btn-lg">重置</button>
+                    </div>
+                </form>
+
+                <!-- 結果區塊 -->
+                <div id="resultSection" class="result-section hidden">
+                    <h2 class="result-title">生成的模板</h2>
+                    <div class="card">
+                        <div class="card-body">
+                            <pre id="resultText" class="result-text"></pre>
+                        </div>
+                    </div>
+
+                    <div id="charCountDisplay" class="char-count-display">
+                        <span id="charCount">0</span> / 1000 字
+                    </div>
+                    <div id="charLimitWarning" class="char-limit-warning hidden">
+                        超過 1000 字限制！請精簡內容後再提交檢舉。
+                    </div>
+
+                    <div class="action-buttons">
+                        <button id="copyBtn" class="btn btn-success btn-lg">
+                            <span class="btn-icon">📋</span><span class="btn-text">複製到剪貼簿</span>
+                        </button>
+                        <a href="https://www.ffxiv.com.tw/web/support/new_question.aspx" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-lg">
+                            <span class="btn-icon">🔗</span>前往官方檢舉頁面
+                        </a>
+                    </div>
+
+                    <div class="warning-message">
+                        <strong>提示：</strong>請在官方檢舉頁面選擇「<strong>不當行為檢舉</strong>」分類
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+    <script src="../../assets/js/security-utils.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/report-generator/script.js
+++ b/tools/report-generator/script.js
@@ -1,0 +1,370 @@
+/**
+ * FF14.tw 檢舉模板產生器
+ * 協助玩家快速產生不當行為檢舉的模板文字
+ */
+
+class ReportGenerator {
+    static MAX_CHAR_LIMIT = 1000;
+
+    constructor() {
+        this.elements = {
+            form: document.getElementById('reportForm'),
+            incidentDate: document.getElementById('incidentDate'),
+            timeStart: document.getElementById('timeStart'),
+            timeEnd: document.getElementById('timeEnd'),
+            playerName: document.getElementById('playerName'),
+            serverSelect: document.getElementById('serverSelect'),
+            serverCustom: document.getElementById('serverCustom'),
+            location: document.getElementById('location'),
+            incidentType: document.getElementById('incidentType'),
+            incidentTypeCustom: document.getElementById('incidentTypeCustom'),
+            details: document.getElementById('details'),
+            resetBtn: document.getElementById('resetBtn'),
+            resultSection: document.getElementById('resultSection'),
+            resultText: document.getElementById('resultText'),
+            copyBtn: document.getElementById('copyBtn'),
+            charCountDisplay: document.getElementById('charCountDisplay'),
+            charCount: document.getElementById('charCount'),
+            charLimitWarning: document.getElementById('charLimitWarning')
+        };
+
+        this.initializeDefaults();
+        this.bindEvents();
+        this.cacheCopyButtonElements();
+    }
+
+    /**
+     * 快取複製按鈕的子元素引用
+     */
+    cacheCopyButtonElements() {
+        this.copyBtnIcon = this.elements.copyBtn.querySelector('.btn-icon');
+        this.copyBtnText = this.elements.copyBtn.querySelector('.btn-text');
+    }
+
+    /**
+     * 設定預設值
+     */
+    initializeDefaults() {
+        // 設定今天的日期為預設值
+        const today = new Date();
+        const year = today.getFullYear();
+        const month = String(today.getMonth() + 1).padStart(2, '0');
+        const day = String(today.getDate()).padStart(2, '0');
+        this.elements.incidentDate.value = `${year}-${month}-${day}`;
+    }
+
+    /**
+     * 綁定事件
+     */
+    bindEvents() {
+        // 表單提交
+        this.elements.form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            this.generateReport();
+        });
+
+        // 重置按鈕
+        this.elements.resetBtn.addEventListener('click', () => {
+            this.resetForm();
+        });
+
+        // 伺服器選擇變更 - 顯示/隱藏自訂輸入框
+        this.elements.serverSelect.addEventListener('change', (e) => {
+            this.toggleCustomInput(e.target, this.elements.serverCustom);
+        });
+
+        // 事件類別選擇變更 - 顯示/隱藏自訂輸入框
+        this.elements.incidentType.addEventListener('change', (e) => {
+            this.toggleCustomInput(e.target, this.elements.incidentTypeCustom);
+        });
+
+        // 複製按鈕
+        this.elements.copyBtn.addEventListener('click', () => {
+            this.copyToClipboard();
+        });
+    }
+
+    /**
+     * 切換自訂輸入框的顯示狀態
+     * @param {HTMLSelectElement} selectElement - 選擇框元素
+     * @param {HTMLInputElement} customInput - 自訂輸入框元素
+     */
+    toggleCustomInput(selectElement, customInput) {
+        if (selectElement.value === 'other') {
+            customInput.classList.remove('hidden');
+            customInput.required = true;
+            customInput.focus();
+        } else {
+            customInput.classList.add('hidden');
+            customInput.required = false;
+            customInput.value = '';
+        }
+    }
+
+    /**
+     * 取得伺服器名稱
+     * @returns {string} 伺服器名稱
+     */
+    getServerName() {
+        if (this.elements.serverSelect.value === 'other') {
+            return this.elements.serverCustom.value.trim();
+        }
+        return this.elements.serverSelect.value;
+    }
+
+    /**
+     * 取得事件類別
+     * @returns {string} 事件類別
+     */
+    getIncidentType() {
+        if (this.elements.incidentType.value === 'other') {
+            return this.elements.incidentTypeCustom.value.trim();
+        }
+        return this.elements.incidentType.value;
+    }
+
+    /**
+     * 格式化日期為 YYYY/MM/DD
+     * @param {string} dateString - 日期字串 (YYYY-MM-DD)
+     * @returns {string} 格式化後的日期
+     */
+    formatDate(dateString) {
+        if (!dateString) return '';
+        return dateString.replace(/-/g, '/');
+    }
+
+    /**
+     * 格式化時間範圍
+     * @returns {string} 格式化後的時間範圍，若無則返回空字串
+     */
+    formatTimeRange() {
+        const start = this.elements.timeStart.value;
+        const end = this.elements.timeEnd.value;
+
+        if (start && end) {
+            return `${start} ~ ${end}`;
+        } else if (start) {
+            return `${start} 左右`;
+        } else if (end) {
+            return `${end} 左右`;
+        }
+        return '';
+    }
+
+    /**
+     * 驗證表單
+     * @returns {boolean} 是否驗證通過
+     */
+    validateForm() {
+        const requiredFields = [
+            { element: this.elements.playerName, name: '被檢舉玩家名稱' },
+            { element: this.elements.location, name: '事件發生地點' },
+            { element: this.elements.details, name: '事件細節' }
+        ];
+
+        // 檢查必填欄位
+        for (const field of requiredFields) {
+            if (!field.element.value.trim()) {
+                this.showError(`請填寫「${field.name}」`);
+                field.element.focus();
+                return false;
+            }
+        }
+
+        // 檢查自訂選擇欄位（伺服器、事件類別）
+        const customSelects = [
+            {
+                select: this.elements.serverSelect,
+                custom: this.elements.serverCustom,
+                getValue: () => this.getServerName(),
+                errorMsg: '請選擇或輸入伺服器名稱'
+            },
+            {
+                select: this.elements.incidentType,
+                custom: this.elements.incidentTypeCustom,
+                getValue: () => this.getIncidentType(),
+                errorMsg: '請選擇或輸入事件類別'
+            }
+        ];
+
+        for (const field of customSelects) {
+            if (!field.getValue()) {
+                this.showError(field.errorMsg);
+                const focusTarget = field.select.value === 'other' ? field.custom : field.select;
+                focusTarget.focus();
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * 顯示錯誤訊息
+     * @param {string} message - 錯誤訊息
+     */
+    showError(message) {
+        if (typeof FF14Utils !== 'undefined' && FF14Utils.showToast) {
+            FF14Utils.showToast(message, 'error');
+        } else {
+            alert(message);
+        }
+    }
+
+    /**
+     * 顯示成功訊息
+     * @param {string} message - 成功訊息
+     */
+    showSuccess(message) {
+        if (typeof FF14Utils !== 'undefined' && FF14Utils.showToast) {
+            FF14Utils.showToast(message, 'success');
+        } else {
+            alert(message);
+        }
+    }
+
+    /**
+     * 產生檢舉模板
+     */
+    generateReport() {
+        if (!this.validateForm()) {
+            return;
+        }
+
+        const date = this.formatDate(this.elements.incidentDate.value);
+        const timeRange = this.formatTimeRange();
+        const playerName = this.elements.playerName.value.trim();
+        const serverName = this.getServerName();
+        const location = this.elements.location.value.trim();
+        const incidentType = this.getIncidentType();
+        const details = this.elements.details.value.trim();
+
+        // 建立模板文字
+        let template = `【不當行為檢舉】\n\n`;
+        template += `■ 發生日期：${date}\n`;
+
+        if (timeRange) {
+            template += `■ 發生時間：${timeRange}\n`;
+        }
+
+        template += `■ 被檢舉玩家名稱：${playerName}\n`;
+        template += `■ 被檢舉玩家所屬伺服器：${serverName}\n`;
+        template += `■ 事件發生地點：${location}\n`;
+        template += `■ 事件類別：${incidentType}\n\n`;
+        template += `■ 事件細節：\n${details}`;
+
+        // 顯示結果（使用安全的 textContent）
+        this.elements.resultText.textContent = template;
+        this.elements.resultSection.classList.remove('hidden');
+
+        // 更新字數統計
+        this.updateCharacterCount(template);
+
+        // 自動複製到剪貼簿
+        this.copyToClipboard(true);
+
+        // 滾動到結果區塊
+        this.elements.resultSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
+    /**
+     * 更新字數統計
+     * @param {string} text - 模板文字
+     */
+    updateCharacterCount(text) {
+        const count = text.length;
+        this.elements.charCount.textContent = count;
+
+        if (count > ReportGenerator.MAX_CHAR_LIMIT) {
+            this.elements.charCountDisplay.classList.add('over-limit');
+            this.elements.charLimitWarning.classList.remove('hidden');
+        } else {
+            this.elements.charCountDisplay.classList.remove('over-limit');
+            this.elements.charLimitWarning.classList.add('hidden');
+        }
+    }
+
+    /**
+     * 更新複製按鈕的內容（使用快取元素優化效能）
+     * @param {string} icon - 圖示字元
+     * @param {string} text - 按鈕文字
+     */
+    updateCopyButtonContent(icon, text) {
+        this.copyBtnIcon.textContent = icon;
+        this.copyBtnText.textContent = text;
+    }
+
+    /**
+     * 複製到剪貼簿
+     * @param {boolean} isAutomatic - 是否為自動複製（產生模板時自動觸發）
+     */
+    async copyToClipboard(isAutomatic = false) {
+        const text = this.elements.resultText.textContent;
+        const successMessage = isAutomatic ? '已產生並複製到剪貼簿！' : '已複製到剪貼簿！';
+
+        try {
+            await navigator.clipboard.writeText(text);
+            this.showSuccess(successMessage);
+
+            // 暫時更新按鈕文字（使用安全的 DOM 操作）
+            this.updateCopyButtonContent('✓', '已複製！');
+            this.elements.copyBtn.classList.add('btn-success-active');
+
+            setTimeout(() => {
+                this.updateCopyButtonContent('📋', '複製到剪貼簿');
+                this.elements.copyBtn.classList.remove('btn-success-active');
+            }, 2000);
+        } catch (err) {
+            // 備用方案：使用舊版 API
+            this.fallbackCopyToClipboard(text);
+        }
+    }
+
+    /**
+     * 備用複製方法（舊版瀏覽器）
+     * @param {string} text - 要複製的文字
+     */
+    fallbackCopyToClipboard(text) {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.left = '-9999px';
+        textarea.style.top = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+
+        try {
+            document.execCommand('copy');
+            this.showSuccess('已複製到剪貼簿！');
+        } catch (err) {
+            this.showError('複製失敗，請手動選取複製');
+        }
+
+        document.body.removeChild(textarea);
+    }
+
+    /**
+     * 重置表單
+     */
+    resetForm() {
+        this.elements.form.reset();
+        this.initializeDefaults();
+
+        // 隱藏自訂輸入框
+        this.elements.serverCustom.classList.add('hidden');
+        this.elements.serverCustom.required = false;
+        this.elements.incidentTypeCustom.classList.add('hidden');
+        this.elements.incidentTypeCustom.required = false;
+
+        // 隱藏結果區塊
+        this.elements.resultSection.classList.add('hidden');
+
+        // 滾動到頂部
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+}
+
+// 頁面載入後初始化
+document.addEventListener('DOMContentLoaded', function() {
+    new ReportGenerator();
+});

--- a/tools/report-generator/style.css
+++ b/tools/report-generator/style.css
@@ -1,0 +1,272 @@
+/**
+ * FF14.tw 檢舉模板產生器樣式
+ */
+
+/* 隱藏元素 */
+.hidden {
+    display: none;
+}
+
+/* Noscript 導航樣式 */
+.noscript-nav {
+    padding: 1rem;
+    background: #667eea;
+    color: white;
+    text-align: center;
+}
+
+.noscript-nav-link {
+    color: white;
+    margin: 0 1rem;
+}
+
+/* 頁面標題區 */
+.page-header {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+.page-header .description {
+    font-size: 1.1rem;
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+/* 工具內容區 */
+.tool-content {
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+/* 表單樣式 */
+.report-form {
+    background: var(--surface, #ffffff);
+    border-radius: 12px;
+    padding: 2rem;
+    box-shadow: var(--shadow-md);
+}
+
+[data-theme="dark"] .report-form {
+    background: var(--card-bg);
+}
+
+/* 表單群組 */
+.form-group {
+    margin-bottom: 1.5rem;
+}
+
+.form-label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    color: var(--text-color);
+}
+
+.required {
+    color: var(--danger-color, #dc3545);
+}
+
+/* 表單說明文字 */
+.form-text {
+    display: block;
+    margin-top: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--text-muted, #999);
+}
+
+/* Fieldset 重置樣式 */
+.form-group fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+    min-width: 0;
+}
+
+.form-group fieldset legend {
+    padding: 0;
+    margin-bottom: 0.5rem;
+}
+
+/* 時間範圍輸入 */
+.time-range {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.time-input {
+    flex: 1;
+    max-width: 150px;
+}
+
+.time-separator {
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+/* 自訂輸入框 */
+.custom-input {
+    margin-top: 0.75rem;
+}
+
+/* 按鈕群組 */
+.button-group {
+    display: flex;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.button-group .btn {
+    flex: 1;
+}
+
+/* 結果區塊 */
+.result-section {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 2px solid var(--border, #e0e0e0);
+}
+
+.result-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+    color: var(--text-color);
+}
+
+/* 結果文字 */
+.result-text {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-family: inherit;
+    font-size: 0.95rem;
+    line-height: 1.8;
+    margin: 0;
+    padding: 1.5rem;
+    background: var(--background, #f8f9fa);
+    border-radius: 8px;
+    color: var(--text-color);
+}
+
+[data-theme="dark"] .result-text {
+    background: var(--bg-secondary);
+}
+
+/* 動作按鈕區 */
+.action-buttons {
+    display: flex;
+    gap: 1rem;
+    margin-top: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.action-buttons .btn {
+    flex: 1;
+    min-width: 200px;
+}
+
+/* 按鈕圖示 */
+.btn-icon {
+    margin-right: 0.5rem;
+}
+
+/* 複製成功狀態 */
+#copyBtn.btn-success-active {
+    background-color: var(--success-color, #28a745);
+    border-color: var(--success-color, #28a745);
+}
+
+/* 警告訊息 */
+.warning-message {
+    margin-top: 1.5rem;
+    padding: 1rem 1.25rem;
+    background: linear-gradient(135deg, #fff3cd 0%, #ffeaa7 100%);
+    border: 1px solid #ffc107;
+    border-radius: 8px;
+    color: #856404;
+    font-size: 0.95rem;
+}
+
+[data-theme="dark"] .warning-message {
+    background: linear-gradient(135deg, rgba(255, 193, 7, 0.2) 0%, rgba(255, 193, 7, 0.1) 100%);
+    border-color: rgba(255, 193, 7, 0.5);
+    color: #ffc107;
+}
+
+/* 字數統計顯示 */
+.char-count-display {
+    text-align: right;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    margin-top: 0.5rem;
+}
+
+.char-count-display.over-limit {
+    color: var(--danger-color, #dc3545);
+    font-weight: 600;
+}
+
+/* 字數限制警告 */
+.char-limit-warning {
+    margin-top: 1rem;
+    padding: 1rem;
+    background: linear-gradient(135deg, #f8d7da 0%, #f5c6cb 100%);
+    border: 1px solid #dc3545;
+    border-radius: 8px;
+    color: #721c24;
+    font-weight: 500;
+}
+
+[data-theme="dark"] .char-limit-warning {
+    background: linear-gradient(135deg, rgba(220, 53, 69, 0.2) 0%, rgba(220, 53, 69, 0.1) 100%);
+    border-color: rgba(220, 53, 69, 0.5);
+    color: #f5c6cb;
+}
+
+/* 響應式設計 */
+@media (max-width: 768px) {
+    .report-form {
+        padding: 1.5rem;
+    }
+
+    .time-range {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .time-input {
+        max-width: none;
+    }
+
+    .time-separator {
+        text-align: center;
+        padding: 0.25rem 0;
+    }
+
+    .button-group {
+        flex-direction: column;
+    }
+
+    .action-buttons {
+        flex-direction: column;
+    }
+
+    .action-buttons .btn {
+        min-width: auto;
+    }
+}
+
+@media (max-width: 480px) {
+    .page-header .description {
+        font-size: 1rem;
+    }
+
+    .report-form {
+        padding: 1.25rem;
+    }
+
+    .result-text {
+        padding: 1rem;
+        font-size: 0.9rem;
+    }
+}


### PR DESCRIPTION
## Summary
- 新增檢舉模板產生器工具，協助 FF14 繁中版玩家快速產生不當行為檢舉的模板文字
- 支援選擇伺服器（伊弗利特、迦樓羅、利維坦、鳳凰、奧汀、巴哈姆特、其他）
- 支援選擇事件類別（強迫玩家跳劇情、違反規範的 ID 名稱、違反規範的名片內容、惡意 BM、破壞遊戲體驗、其他）
- 新增 1000 字數限制檢查與警告提示
- 產生模板時自動複製到剪貼簿
- 提供前往官方檢舉頁面的連結

## Test plan
- [ ] 驗證表單填寫與驗證功能正常
- [ ] 驗證模板產生格式正確
- [ ] 驗證字數統計與超過 1000 字警告顯示正確
- [ ] 驗證自動複製到剪貼簿功能
- [ ] 驗證前往官方檢舉頁面連結正確
- [ ] 驗證深色模式樣式正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)