### PR TITLE
fix: 修復檢舉模板產生器的 i18n 和導航欄顯示問題

### DIFF
--- a/assets/js/i18n/translations/index.js
+++ b/assets/js/i18n/translations/index.js
@@ -39,6 +39,9 @@ const IndexTranslations = {
         tool_guide_title: '攻略資料',
         tool_guide_desc: 'FF14 新手攻略指南，包含公會、軍階、副本、風脈與探索筆記說明',
 
+        tool_report_generator_title: '檢舉模板產生器',
+        tool_report_generator_desc: '快速產生不當行為檢舉的模板文字，協助您進行申訴',
+
         tool_equipment_analyzer_title: '裝備分析器',
         tool_equipment_analyzer_desc: '分析裝備屬性和配裝建議，提供最佳配裝方案',
 
@@ -83,6 +86,9 @@ const IndexTranslations = {
         tool_guide_title: 'Game Guide',
         tool_guide_desc: 'FF14 beginner guide covering guilds, ranks, dungeons, aether currents, and sightseeing log',
 
+        tool_report_generator_title: 'Report Generator',
+        tool_report_generator_desc: 'Quickly generate report templates for reporting inappropriate behavior',
+
         tool_equipment_analyzer_title: 'Equipment Analyzer',
         tool_equipment_analyzer_desc: 'Analyze equipment stats and provide optimal gear recommendations',
 
@@ -126,6 +132,9 @@ const IndexTranslations = {
 
         tool_guide_title: '攻略情報',
         tool_guide_desc: 'FF14初心者ガイド。FC、GC階級、ダンジョン、風脈、探検手帳を含む',
+
+        tool_report_generator_title: '通報テンプレート生成',
+        tool_report_generator_desc: '不適切な行為の通報テンプレートを素早く作成',
 
         tool_equipment_analyzer_title: '装備分析器',
         tool_equipment_analyzer_desc: '装備ステータスを分析し、最適な装備を提案',

--- a/tools/report-generator/index.html
+++ b/tools/report-generator/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="header-placeholder" data-base-path="../../" data-tool-name="FF14.tw | 檢舉模板產生器"></div>
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="檢舉模板產生器"></div>
     <noscript>
         <nav class="noscript-nav">
             <a href="/" class="noscript-nav-link">首頁</a>


### PR DESCRIPTION
## Summary
- 修復首頁檢舉模板產生器工具卡片顯示 i18n key 而非翻譯文字的問題
- 修復 report-generator 導航欄重複顯示 "FF14.tw | FF14.tw | 檢舉模板產生器" 的問題

## Changes
1. **assets/js/i18n/translations/index.js**
   - 新增 `tool_report_generator_title` 翻譯 (zh/en/ja)
   - 新增 `tool_report_generator_desc` 翻譯 (zh/en/ja)

2. **tools/report-generator/index.html**
   - 將 `data-tool-name="FF14.tw | 檢舉模板產生器"` 改為 `data-tool-name="檢舉模板產生器"`
   - nav-template.js 會自動添加 "FF14.tw | " 前綴

## Test plan
- [ ] 檢查首頁檢舉模板產生器工具卡片是否正確顯示標題和描述
- [ ] 檢查 report-generator 頁面導航欄是否正確顯示 "FF14.tw | 檢舉模板產生器"
- [ ] 切換語言確認首頁翻譯正確 (en/ja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)