### PR TITLE
feat: 新增攻略資料隊伍系統頁面

### DIFF
--- a/assets/js/i18n/translations/tools/guide.js
+++ b/assets/js/i18n/translations/tools/guide.js
@@ -19,6 +19,7 @@ const GuideTranslations = {
         guide_toc_guild: '公會',
         guide_toc_grand_company: '大國防聯軍',
         guide_toc_dungeon: '副本',
+        guide_toc_party: '隊伍系統',
         guide_toc_aether: '風脈',
         guide_toc_sightseeing: '探索筆記',
 
@@ -26,6 +27,7 @@ const GuideTranslations = {
         guide_guild_desc: '部隊系統、加入方式與福利',
         guide_grand_company_desc: '三大軍團、軍階系統與軍票',
         guide_dungeon_desc: '副本類型與開放條件',
+        guide_party_desc: '組隊方式、職能配置與跨服機制',
         guide_aether_desc: '風脈泉解鎖與飛行系統',
         guide_sightseeing_desc: '探索筆記機制與獎勵',
 
@@ -33,6 +35,7 @@ const GuideTranslations = {
         guide_section_guild_title: '公會',
         guide_section_grand_company_title: '大國防聯軍',
         guide_section_dungeon_title: '副本',
+        guide_section_party_title: '隊伍系統',
         guide_section_aether_title: '風脈',
         guide_section_sightseeing_title: '探索筆記',
         guide_section_chocobo_title: '專屬陸行鳥',
@@ -76,6 +79,7 @@ const GuideTranslations = {
         guide_toc_guild: 'Free Company',
         guide_toc_grand_company: 'Grand Company',
         guide_toc_dungeon: 'Dungeons',
+        guide_toc_party: 'Party System',
         guide_toc_aether: 'Aether Currents',
         guide_toc_sightseeing: 'Sightseeing Log',
 
@@ -83,6 +87,7 @@ const GuideTranslations = {
         guide_guild_desc: 'FC system, how to join, and benefits',
         guide_grand_company_desc: 'Three nations, ranks and company seals',
         guide_dungeon_desc: 'Dungeon types and unlock requirements',
+        guide_party_desc: 'Party formation, role composition and cross-world mechanics',
         guide_aether_desc: 'Aether currents and flying unlock',
         guide_sightseeing_desc: 'Sightseeing log mechanics and rewards',
 
@@ -90,6 +95,7 @@ const GuideTranslations = {
         guide_section_guild_title: 'Free Company',
         guide_section_grand_company_title: 'Grand Company',
         guide_section_dungeon_title: 'Dungeons',
+        guide_section_party_title: 'Party System',
         guide_section_aether_title: 'Aether Currents',
         guide_section_sightseeing_title: 'Sightseeing Log',
         guide_section_chocobo_title: 'Chocobo Companion',
@@ -133,6 +139,7 @@ const GuideTranslations = {
         guide_toc_guild: 'フリーカンパニー',
         guide_toc_grand_company: 'グランドカンパニー',
         guide_toc_dungeon: 'ダンジョン',
+        guide_toc_party: 'パーティシステム',
         guide_toc_aether: '風脈',
         guide_toc_sightseeing: '探検手帳',
 
@@ -140,6 +147,7 @@ const GuideTranslations = {
         guide_guild_desc: 'FCシステム、参加方法、特典',
         guide_grand_company_desc: '三国軍、階級システムと軍票',
         guide_dungeon_desc: 'ダンジョンの種類と開放条件',
+        guide_party_desc: 'パーティ編成、ロール構成、クロスワールドの仕組み',
         guide_aether_desc: '風脈の解放とフライング',
         guide_sightseeing_desc: '探検手帳の仕組みと報酬',
 
@@ -147,6 +155,7 @@ const GuideTranslations = {
         guide_section_guild_title: 'フリーカンパニー',
         guide_section_grand_company_title: 'グランドカンパニー',
         guide_section_dungeon_title: 'ダンジョン',
+        guide_section_party_title: 'パーティシステム',
         guide_section_aether_title: '風脈',
         guide_section_sightseeing_title: '探検手帳',
         guide_section_chocobo_title: 'バディチョコボ',

--- a/tools/guide/aether.html
+++ b/tools/guide/aether.html
@@ -54,8 +54,8 @@
 
                 <!-- Page Navigation -->
                 <nav class="page-nav">
-                    <a href="dungeon.html" class="page-nav-prev">
-                        ← <span data-i18n="guide_toc_dungeon">副本</span>
+                    <a href="party.html" class="page-nav-prev">
+                        ← <span data-i18n="guide_toc_party">隊伍系統</span>
                     </a>
                     <a href="sightseeing.html" class="page-nav-next">
                         <span data-i18n="guide_toc_sightseeing">探索筆記</span> →

--- a/tools/guide/dungeon.html
+++ b/tools/guide/dungeon.html
@@ -57,8 +57,8 @@
                     <a href="grand-company.html" class="page-nav-prev">
                         ← <span data-i18n="guide_toc_grand_company">大國防聯軍</span>
                     </a>
-                    <a href="aether.html" class="page-nav-next">
-                        <span data-i18n="guide_toc_aether">風脈</span> →
+                    <a href="party.html" class="page-nav-next">
+                        <span data-i18n="guide_toc_party">隊伍系統</span> →
                     </a>
                 </nav>
             </div>

--- a/tools/guide/index.html
+++ b/tools/guide/index.html
@@ -55,6 +55,11 @@
                         <p class="guide-card-desc" data-i18n="guide_dungeon_desc">副本類型與開放條件</p>
                     </a>
 
+                    <a href="party.html" class="guide-card">
+                        <h2 class="guide-card-title" data-i18n="guide_toc_party">隊伍系統</h2>
+                        <p class="guide-card-desc" data-i18n="guide_party_desc">組隊方式、職能配置與跨服機制</p>
+                    </a>
+
                     <a href="aether.html" class="guide-card">
                         <h2 class="guide-card-title" data-i18n="guide_toc_aether">風脈</h2>
                         <p class="guide-card-desc" data-i18n="guide_aether_desc">風脈泉解鎖與飛行系統</p>

--- a/tools/guide/party.html
+++ b/tools/guide/party.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>隊伍系統 - 攻略資料 - FF14.tw</title>
+    <meta name="description" content="FF14 隊伍系統完整說明，包含 Light Party、Full Party、跨服小隊、聯盟團隊與職能配置">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+
+    <!-- Required CSS imports -->
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- Header placeholder -->
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="攻略資料" data-tool-name-key="guide_header"></div>
+
+    <!-- Noscript fallback -->
+    <noscript>
+        <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
+            <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
+            <a href="/copyright.html" style="color: white; margin: 0 1rem;">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" style="color: white; margin: 0 1rem;">GitHub</a>
+            <a href="/about.html" style="color: white; margin: 0 1rem;">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container guide-layout">
+            <!-- Sidebar placeholder -->
+            <div id="guide-sidebar-placeholder" data-current-page="party"></div>
+
+            <!-- Main Content Wrapper -->
+            <div class="guide-content-wrapper">
+                <article class="guide-article">
+                    <h1 class="article-title">
+                        <span class="article-icon">👥</span>
+                        <span data-i18n="guide_section_party_title">隊伍系統</span>
+                    </h1>
+                    <div class="article-content">
+
+                        <h2>建立隊伍的方法</h2>
+                        <p>在艾歐乍亞的冒險旅途中，與其他玩家組成隊伍是挑戰各種內容的基礎。以下是常見的組隊方式：</p>
+                        <ul>
+                            <li><strong>玩家名牌邀請</strong>：點選其他玩家的名牌，透過選單直接發送組隊邀請</li>
+                            <li><strong>招募板（Party Finder）</strong>：使用公開招募功能，讓其他玩家主動申請加入</li>
+                            <li><strong>任務搜尋器（Duty Finder）</strong>：系統自動配對，快速組成符合職能需求的隊伍</li>
+                        </ul>
+
+                        <h3>隊長機制</h3>
+                        <p>發起組隊的玩家會自動成為隊長，隊長可以將此職位轉讓給其他成員。</p>
+                        <p>隊長擁有以下專屬權限：</p>
+                        <ul>
+                            <li>邀請新成員加入隊伍</li>
+                            <li>移除現有成員</li>
+                            <li>解散整支隊伍</li>
+                            <li>發起任務搜尋器申請（僅隊長的設定會生效）</li>
+                        </ul>
+
+                        <h2>Light Party（輕裝小隊）</h2>
+                        <p>當隊伍人數介於 4 至 7 人時，系統會將其歸類為 Light Party。這是四人副本的標準編制。</p>
+
+                        <h3>標準職能配置（4人）</h3>
+                        <ul>
+                            <li><strong>1 名坦克（Tank）</strong>：負責吸引敵人仇恨、承受傷害</li>
+                            <li><strong>1 名治療（Healer）</strong>：負責恢復隊友生命值</li>
+                            <li><strong>2 名輸出（DPS）</strong>：負責造成傷害擊敗敵人</li>
+                        </ul>
+
+                        <h3>特點</h3>
+                        <ul>
+                            <li>極限技量表（LB）開啟一格，最高可累積至兩格</li>
+                            <li>啟用「自由配對」功能可忽略職能限制進入副本</li>
+                        </ul>
+
+                        <h2>Full Party（滿編小隊）</h2>
+                        <p>當隊伍達到 8 人時，即為 Full Party。這是八人副本（如極蠻神、零式副本）的標準編制。</p>
+
+                        <h3>標準職能配置（8人）</h3>
+                        <ul>
+                            <li><strong>2 名坦克</strong>：主坦（MT）與副坦（ST/OT）</li>
+                            <li><strong>2 名治療</strong>：通常為純治療搭配護盾治療</li>
+                            <li><strong>4 名輸出</strong>：近戰與遠程的組合</li>
+                        </ul>
+
+                        <h3>特點</h3>
+                        <ul>
+                            <li>極限技量表開啟兩格，最高可累積至三格</li>
+                            <li>同樣可透過「自由配對」忽略職能限制</li>
+                        </ul>
+
+                        <h2>跨服小隊機制</h2>
+                        <p>當邀請不同伺服器的玩家組隊，或透過跨服招募時，會自動建立跨服小隊。</p>
+
+                        <h3>可執行的功能</h3>
+                        <ul>
+                            <li>小隊聊天頻道</li>
+                            <li>準備確認</li>
+                            <li>任務搜尋器申請</li>
+                            <li>大型任務搜尋器申請</li>
+                            <li>跨界傳送</li>
+                        </ul>
+
+                        <div class="guide-info-card guide-note">
+                            <strong>小知識：</strong>本服小隊需要先解散才能進行跨界傳送，但跨服小隊則可直接傳送。
+                        </div>
+
+                        <h3>7.1 版本更新</h3>
+                        <p>當所有成員位於同一地區時，可將跨服小隊轉換為本服小隊。若有成員正在野外戰鬥中，則無法進行轉換。</p>
+
+                        <h3>跨服小隊的限制</h3>
+                        <p>以下內容無法透過跨服小隊招募：</p>
+                        <ul>
+                            <li>任務戰鬥</li>
+                            <li>危命任務（FATE）</li>
+                            <li>挖寶</li>
+                            <li>狩獵怪物</li>
+                        </ul>
+
+                        <div class="guide-info-card guide-warning">
+                            <strong>注意：</strong>在跨服小隊狀態下進行野外戰鬥（包含 FATE 與狩獵），將視為單人作戰，無法享受組隊加成與獎勵共享。
+                        </div>
+
+                        <h2>Alliance（聯盟）</h2>
+                        <p>聯盟由多支小隊組成，通常為 3 支小隊（24人），部分特殊任務最多可達 6 支小隊（48人）。</p>
+
+                        <h3>聯盟副本標準配置（每隊 8 人）</h3>
+                        <ul>
+                            <li><strong>1 名坦克</strong></li>
+                            <li><strong>2 名治療</strong></li>
+                            <li><strong>5 名輸出</strong></li>
+                        </ul>
+                        <p>組成聯盟後，各項功能仍以小隊為單位運作，但可透過聯盟列表觀察其他隊伍的狀態。</p>
+
+                        <h2>成員排序</h2>
+                        <p>預設排序依職能由上至下為：坦克 → 治療 → DPS</p>
+
+                        <h3>自訂排序</h3>
+                        <ul>
+                            <li>開啟角色設定（K）→ 介面設定 → 小隊列表</li>
+                            <li>可依據當前職能設定不同的排序方式</li>
+                            <li>進入副本時會自動套用設定</li>
+                        </ul>
+
+                        <h3>手動排序</h3>
+                        <p>透過選單 → 小隊 → 小隊成員 → 成員排序</p>
+
+                        <div class="guide-info-card guide-tip">
+                            <strong>提示：</strong>玩家在副本中斷線重連後，排序可能會被打亂，需手動點擊排序按鈕重新整理。
+                        </div>
+
+                        <h3>7.1 版本新增功能</h3>
+                        <ul>
+                            <li>可調整自身角色在列表中的位置</li>
+                            <li>支援滑鼠拖曳進行排序</li>
+                            <li>透過小隊選單的切換按鈕啟用/停用拖曳功能</li>
+                        </ul>
+
+                        <h2>成員編號與巨集應用</h2>
+                        <p>小隊列表由上至下編號為 1-8，其中編號 1 固定為自己。</p>
+                        <p>可透過文字指令與巨集快速指定目標，例如：</p>
+                        <pre><code>/ac 治療 &lt;2&gt;</code></pre>
+                        <p>此指令可在不切換目標的情況下，對編號 2 的隊友施放「治療」技能。</p>
+
+                        <h2>職能多樣性加成</h2>
+                        <p>隊伍中每增加一種不同的職能類別，全體成員的主要屬性（力量、敏捷、耐力、智力、精神）將提升 1%，最高可達 5%。</p>
+
+                        <h3>職能分類表</h3>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>職能類別</th>
+                                    <th>包含職業</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>坦克（Tank）</td>
+                                    <td>劍術師/騎士、斧術師/戰士、暗黑騎士、絕槍戰士</td>
+                                </tr>
+                                <tr>
+                                    <td>近戰 DPS</td>
+                                    <td>格鬥家/武僧、槍術師/龍騎士、雙劍師/忍者、武士、鐮刀客、蝮蛇劍士</td>
+                                </tr>
+                                <tr>
+                                    <td>遠程物理 DPS</td>
+                                    <td>弓箭手/吟遊詩人、機工士、舞者</td>
+                                </tr>
+                                <tr>
+                                    <td>遠程魔法 DPS</td>
+                                    <td>咒術師/黑魔法師、秘術師/召喚師、赤魔法師、繪靈法師、青魔法師</td>
+                                </tr>
+                                <tr>
+                                    <td>治療（Healer）</td>
+                                    <td>幻術師/白魔法師、學者、占星術士、賢者</td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                    </div>
+                </article>
+
+                <!-- Page Navigation -->
+                <nav class="page-nav">
+                    <a href="dungeon.html" class="page-nav-prev">
+                        ← <span data-i18n="guide_toc_dungeon">副本</span>
+                    </a>
+                    <a href="aether.html" class="page-nav-next">
+                        <span data-i18n="guide_toc_aether">風脈</span> →
+                    </a>
+                </nav>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <!-- Required JS imports -->
+    <script src="../../assets/js/i18n/i18n-manager.js"></script>
+    <script src="../../assets/js/i18n/translations/common.js"></script>
+    <script src="../../assets/js/i18n/translations/tools/guide.js"></script>
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+    <script src="sidebar-template.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/guide/sidebar-template.js
+++ b/tools/guide/sidebar-template.js
@@ -8,6 +8,7 @@ const GuideSidebarTemplate = {
         { href: 'guild.html', page: 'guild', icon: '🏠', i18nKey: 'guide_toc_guild', text: '公會' },
         { href: 'grand-company.html', page: 'grand-company', icon: '🎖️', i18nKey: 'guide_toc_grand_company', text: '大國防聯軍' },
         { href: 'dungeon.html', page: 'dungeon', icon: '🏰', i18nKey: 'guide_toc_dungeon', text: '副本' },
+        { href: 'party.html', page: 'party', icon: '👥', i18nKey: 'guide_toc_party', text: '隊伍系統' },
         { href: 'aether.html', page: 'aether', icon: '💨', i18nKey: 'guide_toc_aether', text: '風脈' },
         { href: 'sightseeing.html', page: 'sightseeing', icon: '📔', i18nKey: 'guide_toc_sightseeing', text: '探索筆記' },
         { href: 'chocobo.html', page: 'chocobo', icon: '🐤', i18nKey: 'guide_toc_chocobo', text: '專屬陸行鳥' }


### PR DESCRIPTION
## Summary
- 新增 `tools/guide/party.html` 隊伍系統說明頁面
- 內容涵蓋 Light Party、Full Party、跨服小隊、Alliance 聯盟等機制
- 包含職能配置、成員排序、巨集應用與組隊加成說明
- 更新 sidebar 導航、index 卡片與相鄰頁面導航連結
- 新增 zh/en/ja 三語翻譯支援

## 變更檔案
| 檔案 | 說明 |
|------|------|
| `tools/guide/party.html` | 新增隊伍系統頁面 |
| `tools/guide/sidebar-template.js` | 新增 party 導航項目 |
| `tools/guide/index.html` | 新增隊伍系統卡片 |
| `tools/guide/dungeon.html` | 更新下一頁連結 |
| `tools/guide/aether.html` | 更新上一頁連結 |
| `assets/js/i18n/translations/tools/guide.js` | 新增多語翻譯 |

## 頁面內容結構
1. 建立隊伍的方法（邀請、招募板、任務搜尋器）
2. Light Party（4-7人編制）
3. Full Party（8人編制）
4. 跨服小隊機制（含 7.1 版本更新）
5. Alliance 聯盟（24人團隊）
6. 成員排序與管理
7. 成員編號與巨集應用
8. 職能多樣性加成

## Test plan
- [ ] 本地伺服器測試 party.html 頁面顯示
- [ ] 確認 sidebar 導航正確顯示並高亮當前頁面
- [ ] 確認 index.html 卡片連結正確
- [ ] 確認 dungeon → party → aether 導航連結正確
- [ ] 測試語言切換功能（中/英/日）
- [ ] 測試深色模式顯示

🤖 Generated with [Claude Code](https://claude.ai/code)