### PR TITLE
feat(weather-forecast): add weather forecast tool for Eorzea zones

### DIFF
--- a/assets/js/i18n/translations/index.js
+++ b/assets/js/i18n/translations/index.js
@@ -45,6 +45,9 @@ const IndexTranslations = {
         tool_macro_converter_title: '巨集轉換器',
         tool_macro_converter_desc: '將 FF14 巨集在繁體中文、英文、日文之間轉換',
 
+        tool_weather_forecast_title: '天氣預報',
+        tool_weather_forecast_desc: '查看艾歐澤亞各地區的天氣預報，搜尋特定天氣條件',
+
         tool_equipment_analyzer_title: '裝備分析器',
         tool_equipment_analyzer_desc: '分析裝備屬性和配裝建議，提供最佳配裝方案',
 
@@ -95,6 +98,9 @@ const IndexTranslations = {
         tool_macro_converter_title: 'Macro Converter',
         tool_macro_converter_desc: 'Convert FF14 macros between Traditional Chinese, English, and Japanese',
 
+        tool_weather_forecast_title: 'Weather Forecast',
+        tool_weather_forecast_desc: 'View weather forecasts for Eorzea zones and search for specific conditions',
+
         tool_equipment_analyzer_title: 'Equipment Analyzer',
         tool_equipment_analyzer_desc: 'Analyze equipment stats and provide optimal gear recommendations',
 
@@ -144,6 +150,9 @@ const IndexTranslations = {
 
         tool_macro_converter_title: 'マクロ変換ツール',
         tool_macro_converter_desc: 'FF14マクロを繁体字中国語、英語、日本語間で変換',
+
+        tool_weather_forecast_title: '天気予報',
+        tool_weather_forecast_desc: 'エオルゼア各地域の天気予報を確認、特定の天気条件を検索',
 
         tool_equipment_analyzer_title: '装備分析器',
         tool_equipment_analyzer_desc: '装備ステータスを分析し、最適な装備を提案',

--- a/assets/js/i18n/translations/tools/weather-forecast.js
+++ b/assets/js/i18n/translations/tools/weather-forecast.js
@@ -153,7 +153,7 @@ const WeatherForecastTranslations = {
         weather_col_local_time: 'Local Time',
         weather_col_eorzea_time: 'ET Time',
         weather_col_weather: 'Weather',
-        weather_col_prev_weather: 'Previous',
+        weather_col_prev_weather: 'Previous Weather',
         weather_col_duration: 'Duration',
 
         // Current time

--- a/assets/js/i18n/translations/tools/weather-forecast.js
+++ b/assets/js/i18n/translations/tools/weather-forecast.js
@@ -1,0 +1,313 @@
+/**
+ * FF14.tw 天氣預報工具翻譯檔
+ */
+const WeatherForecastTranslations = {
+    zh: {
+        // 頁面資訊
+        weather_title: '天氣預報 - FF14.tw',
+        weather_description: '查看艾歐澤亞各地區的天氣預報，搜尋特定天氣條件，追蹤特殊事件',
+
+        // 頁面標題
+        weather_header: '天氣預報',
+
+        // 地區選擇
+        weather_select_zone: '選擇地區',
+        weather_select_zone_hint: '點擊地區按鈕開始查看天氣',
+
+        // 區域名稱
+        region_la_noscea: '拉諾西亞',
+        region_black_shroud: '黑衣森林',
+        region_thanalan: '薩納蘭',
+        region_coerthas: '庫爾札斯',
+        region_mor_dhona: '摩杜納',
+        region_abalathia: '阿巴拉提亞',
+        region_dravania: '龍堡',
+        region_gyr_abania: '基拉巴尼亞',
+        region_othard: '奧薩德',
+        region_norvrandt: '諾弗蘭特',
+        region_ilsabard: '伊爾薩巴德',
+        region_the_sea_of_stars: '星海',
+        region_the_world_unsundered: '未分離的世界',
+        region_tural: '圖拉爾',
+
+        // 過濾器
+        weather_filter_title: '過濾條件',
+        weather_desired_weather: '目標天氣',
+        weather_previous_weather: '前置天氣',
+        weather_time_range: '艾歐澤亞時間範圍',
+        weather_clear_filters: '清除過濾',
+
+        // 時間
+        weather_time_all: '全天',
+        weather_time_custom: '自訂',
+
+        // 結果
+        weather_results: '搜尋結果',
+        weather_timetable: '天氣時刻表',
+        weather_no_results: '沒有符合條件的結果',
+        weather_show_more: '顯示更多',
+        weather_loading: '載入中...',
+
+        // 表格標題
+        weather_col_local_time: '本地時間',
+        weather_col_eorzea_time: 'ET 時間',
+        weather_col_weather: '天氣',
+        weather_col_prev_weather: '前置天氣',
+        weather_col_duration: '持續時間',
+
+        // 當前時間
+        weather_current_et: '目前 ET',
+        weather_current_lt: '本地時間',
+
+        // 特殊事件
+        weather_events: '特殊事件',
+        weather_event_garlok: '哥布林首領',
+        weather_event_laideronnette: '湖中女妖',
+
+        // 狀態
+        weather_current: '目前',
+        weather_upcoming: '即將',
+
+        // 分享
+        weather_share: '分享連結',
+        weather_copied: '已複製到剪貼簿',
+
+        // 天氣類型
+        weather_clear_skies: '晴朗',
+        weather_fair_skies: '碧空',
+        weather_clouds: '陰天',
+        weather_fog: '濃霧',
+        weather_wind: '微風',
+        weather_gales: '強風',
+        weather_rain: '小雨',
+        weather_showers: '陣雨',
+        weather_thunder: '雷雨',
+        weather_thunderstorms: '暴風雨',
+        weather_dust_storms: '沙塵暴',
+        weather_heat_waves: '熱浪',
+        weather_snow: '飄雪',
+        weather_blizzards: '暴風雪',
+        weather_gloom: '薄暗',
+        weather_umbral_wind: '靈風',
+        weather_umbral_static: '靈電',
+        weather_eruptions: '火山灰',
+        weather_moon_dust: '月塵',
+        weather_astromagnetic_storm: '星磁暴',
+        weather_hyperelectricity: '超電磁',
+        weather_royal_levin: '皇雷',
+        weather_shelf_clouds: '弧狀雲',
+        weather_oppression: '悶熱',
+        weather_sunshine: '烈日',
+
+        // 訊息
+        weather_msg_select_zone: '請先選擇一個地區',
+        weather_msg_no_weather: '此地區沒有天氣資料'
+    },
+    en: {
+        // Page info
+        weather_title: 'Weather Forecast - FF14.tw',
+        weather_description: 'View weather forecasts for Eorzea zones, search for specific conditions, track special events',
+
+        // Page header
+        weather_header: 'Weather Forecast',
+
+        // Zone selection
+        weather_select_zone: 'Select Zone',
+        weather_select_zone_hint: 'Click a zone button to view weather',
+
+        // Region names
+        region_la_noscea: 'La Noscea',
+        region_black_shroud: 'The Black Shroud',
+        region_thanalan: 'Thanalan',
+        region_coerthas: 'Coerthas',
+        region_mor_dhona: 'Mor Dhona',
+        region_abalathia: "Abalathia's Spine",
+        region_dravania: 'Dravania',
+        region_gyr_abania: 'Gyr Abania',
+        region_othard: 'Othard',
+        region_norvrandt: 'Norvrandt',
+        region_ilsabard: 'Ilsabard',
+        region_the_sea_of_stars: 'The Sea of Stars',
+        region_the_world_unsundered: 'The World Unsundered',
+        region_tural: 'Tural',
+
+        // Filters
+        weather_filter_title: 'Filters',
+        weather_desired_weather: 'Target Weather',
+        weather_previous_weather: 'Previous Weather',
+        weather_time_range: 'Eorzea Time Range',
+        weather_clear_filters: 'Clear Filters',
+
+        // Time
+        weather_time_all: 'All Day',
+        weather_time_custom: 'Custom',
+
+        // Results
+        weather_results: 'Search Results',
+        weather_timetable: 'Weather Timetable',
+        weather_no_results: 'No matching results',
+        weather_show_more: 'Show More',
+        weather_loading: 'Loading...',
+
+        // Table headers
+        weather_col_local_time: 'Local Time',
+        weather_col_eorzea_time: 'ET Time',
+        weather_col_weather: 'Weather',
+        weather_col_prev_weather: 'Previous',
+        weather_col_duration: 'Duration',
+
+        // Current time
+        weather_current_et: 'Current ET',
+        weather_current_lt: 'Local Time',
+
+        // Special events
+        weather_events: 'Special Events',
+        weather_event_garlok: 'Garlok',
+        weather_event_laideronnette: 'Laideronnette',
+
+        // Status
+        weather_current: 'Current',
+        weather_upcoming: 'Upcoming',
+
+        // Share
+        weather_share: 'Share Link',
+        weather_copied: 'Copied to clipboard',
+
+        // Weather types
+        weather_clear_skies: 'Clear Skies',
+        weather_fair_skies: 'Fair Skies',
+        weather_clouds: 'Clouds',
+        weather_fog: 'Fog',
+        weather_wind: 'Wind',
+        weather_gales: 'Gales',
+        weather_rain: 'Rain',
+        weather_showers: 'Showers',
+        weather_thunder: 'Thunder',
+        weather_thunderstorms: 'Thunderstorms',
+        weather_dust_storms: 'Dust Storms',
+        weather_heat_waves: 'Heat Waves',
+        weather_snow: 'Snow',
+        weather_blizzards: 'Blizzards',
+        weather_gloom: 'Gloom',
+        weather_umbral_wind: 'Umbral Wind',
+        weather_umbral_static: 'Umbral Static',
+        weather_eruptions: 'Eruptions',
+        weather_moon_dust: 'Moon Dust',
+        weather_astromagnetic_storm: 'Astromagnetic Storm',
+        weather_hyperelectricity: 'Hyperelectricity',
+        weather_royal_levin: 'Royal Levin',
+        weather_shelf_clouds: 'Shelf Clouds',
+        weather_oppression: 'Oppression',
+        weather_sunshine: 'Sunshine',
+
+        // Messages
+        weather_msg_select_zone: 'Please select a zone first',
+        weather_msg_no_weather: 'No weather data for this zone'
+    },
+    ja: {
+        // ページ情報
+        weather_title: '天気予報 - FF14.tw',
+        weather_description: 'エオルゼア各地域の天気予報を確認、特定の天気条件を検索、特別なイベントを追跡',
+
+        // ページヘッダー
+        weather_header: '天気予報',
+
+        // 地域選択
+        weather_select_zone: '地域を選択',
+        weather_select_zone_hint: '地域ボタンをクリックして天気を表示',
+
+        // 地域名
+        region_la_noscea: 'ラノシア',
+        region_black_shroud: '黒衣森',
+        region_thanalan: 'ザナラーン',
+        region_coerthas: 'クルザス',
+        region_mor_dhona: 'モードゥナ',
+        region_abalathia: 'アバラシア',
+        region_dravania: 'ドラヴァニア',
+        region_gyr_abania: 'ギラバニア',
+        region_othard: 'オサード',
+        region_norvrandt: 'ノルヴラント',
+        region_ilsabard: 'イルサバード',
+        region_the_sea_of_stars: '星海',
+        region_the_world_unsundered: '未分裂の世界',
+        region_tural: 'トラル',
+
+        // フィルター
+        weather_filter_title: 'フィルター',
+        weather_desired_weather: '目標天気',
+        weather_previous_weather: '前の天気',
+        weather_time_range: 'エオルゼア時間範囲',
+        weather_clear_filters: 'フィルターをクリア',
+
+        // 時間
+        weather_time_all: '全日',
+        weather_time_custom: 'カスタム',
+
+        // 結果
+        weather_results: '検索結果',
+        weather_timetable: '天気時刻表',
+        weather_no_results: '条件に一致する結果がありません',
+        weather_show_more: 'もっと見る',
+        weather_loading: '読み込み中...',
+
+        // テーブルヘッダー
+        weather_col_local_time: 'ローカル時間',
+        weather_col_eorzea_time: 'ET 時間',
+        weather_col_weather: '天気',
+        weather_col_prev_weather: '前の天気',
+        weather_col_duration: '継続時間',
+
+        // 現在時刻
+        weather_current_et: '現在 ET',
+        weather_current_lt: 'ローカル時間',
+
+        // 特別イベント
+        weather_events: '特別イベント',
+        weather_event_garlok: 'ガーロック',
+        weather_event_laideronnette: 'レデロネット',
+
+        // ステータス
+        weather_current: '現在',
+        weather_upcoming: 'まもなく',
+
+        // シェア
+        weather_share: 'リンクをシェア',
+        weather_copied: 'クリップボードにコピーしました',
+
+        // 天気タイプ
+        weather_clear_skies: '快晴',
+        weather_fair_skies: '晴れ',
+        weather_clouds: '曇り',
+        weather_fog: '霧',
+        weather_wind: '風',
+        weather_gales: '暴風',
+        weather_rain: '雨',
+        weather_showers: 'にわか雨',
+        weather_thunder: '雷',
+        weather_thunderstorms: '雷雨',
+        weather_dust_storms: '砂塵',
+        weather_heat_waves: '灼熱波',
+        weather_snow: '雪',
+        weather_blizzards: '吹雪',
+        weather_gloom: '妖霧',
+        weather_umbral_wind: '霊風',
+        weather_umbral_static: '放電',
+        weather_eruptions: '噴煙',
+        weather_moon_dust: '月砂塵',
+        weather_astromagnetic_storm: '星磁嵐',
+        weather_hyperelectricity: '超電磁嵐',
+        weather_royal_levin: '皇雷',
+        weather_shelf_clouds: '弧状雲',
+        weather_oppression: '蒸熱',
+        weather_sunshine: '陽光',
+
+        // メッセージ
+        weather_msg_select_zone: '最初に地域を選択してください',
+        weather_msg_no_weather: 'この地域の天気データがありません'
+    }
+};
+
+// 載入翻譯到全域 i18n
+if (window.i18n) {
+    window.i18n.loadTranslations('weather-forecast', WeatherForecastTranslations);
+}

--- a/changelog.html
+++ b/changelog.html
@@ -45,13 +45,29 @@
 
                     <article class="changelog-entry">
                         <div class="changelog-header">
+                            <h3 class="changelog-version">v2.10.0</h3>
+                            <time class="changelog-date" datetime="2026-01-27">2026年1月27日</time>
+                        </div>
+                        <div class="changelog-content">
+                            <ul>
+                                <li><span class="tag tag-success">新增</span> 天氣預報：全新工具，可查看艾歐澤亞各地區的天氣預報</li>
+                                <li><span class="tag tag-success">新增</span> 天氣預報：支援 78 個地區的天氣查詢</li>
+                                <li><span class="tag tag-success">新增</span> 天氣預報：可過濾目標天氣、前置天氣與艾歐澤亞時間範圍</li>
+                                <li><span class="tag tag-success">新增</span> 天氣預報：即時顯示目前 ET 時間與本地時間</li>
+                                <li><span class="tag tag-success">新增</span> 天氣預報：支援 URL 分享，可分享搜尋條件</li>
+                            </ul>
+                        </div>
+                    </article>
+
+                    <article class="changelog-entry">
+                        <div class="changelog-header">
                             <h3 class="changelog-version">v2.9.1</h3>
                             <time class="changelog-date" datetime="2026-01-10">2026年1月10日</time>
                         </div>
                         <div class="changelog-content">
                             <ul>
                                 <li><span class="tag tag-warning">修正</span> 寶圖搜尋器：修復格式設定面板中的事件監聽器記憶體洩漏問題</li>
-                                <li><span class="tag tag-info">優化</span> 寶圖搜尋器：移除冗餘的事件監聽器以提升效能</li>
+                                <li><span class="tag tag-info">優化</span> 寶圖搜尋器：移除冗餘的事件監聯器以提升效能</li>
                                 <li><span class="tag tag-info">優化</span> 角色卡產生器：改進拖曳功能的事件處理機制，僅在拖曳時監聽移動事件</li>
                             </ul>
                         </div>

--- a/changelog.html
+++ b/changelog.html
@@ -67,7 +67,7 @@
                         <div class="changelog-content">
                             <ul>
                                 <li><span class="tag tag-warning">修正</span> 寶圖搜尋器：修復格式設定面板中的事件監聽器記憶體洩漏問題</li>
-                                <li><span class="tag tag-info">優化</span> 寶圖搜尋器：移除冗餘的事件監聯器以提升效能</li>
+                                <li><span class="tag tag-info">優化</span> 寶圖搜尋器：移除冗餘的事件監聽器以提升效能</li>
                                 <li><span class="tag tag-info">優化</span> 角色卡產生器：改進拖曳功能的事件處理機制，僅在拖曳時監聽移動事件</li>
                             </ul>
                         </div>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
             margin-bottom: 4rem;
             box-shadow: 0 10px 30px rgba(102, 126, 234, 0.3);
         }
-        
+
         .hero h1 {
             font-size: 3rem;
             margin-bottom: 1.5rem;
@@ -30,7 +30,7 @@
             font-weight: 700;
             letter-spacing: 0.5px;
         }
-        
+
         .hero p {
             font-size: 1.3rem;
             opacity: 0.95;
@@ -40,11 +40,11 @@
             margin-right: auto;
             line-height: 1.6;
         }
-        
+
         .tools-section {
             margin-bottom: 4rem;
         }
-        
+
         .tools-section h2 {
             text-align: center;
             font-size: 2.5rem;
@@ -53,7 +53,7 @@
             font-weight: 600;
             position: relative;
         }
-        
+
         .tools-section h2::after {
             content: '';
             position: absolute;
@@ -65,7 +65,7 @@
             background: linear-gradient(90deg, var(--primary-color), var(--secondary-color));
             border-radius: 2px;
         }
-        
+
         .tools-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
@@ -73,7 +73,7 @@
             max-width: 1200px;
             margin: 0 auto;
         }
-        
+
         .tool-card {
             background: white;
             border-radius: 16px;
@@ -86,7 +86,7 @@
             position: relative;
             overflow: hidden;
         }
-        
+
         .tool-card::before {
             content: '';
             position: absolute;
@@ -99,32 +99,32 @@
             transform-origin: left;
             transition: transform 0.3s ease;
         }
-        
+
         .tool-card:hover {
             transform: translateY(-8px);
             box-shadow: 0 12px 40px rgba(0,0,0,0.15);
             border-color: var(--primary-color);
         }
-        
+
         .tool-card:hover::before {
             transform: scaleX(1);
         }
-        
+
         .tool-card.available {
             cursor: pointer;
         }
-        
+
         .tool-card.available:hover .tool-icon {
             transform: scale(1.1) rotate(5deg);
         }
-        
+
         .tool-card.coming-soon {
             opacity: 0.7;
             cursor: not-allowed;
             background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
             position: relative;
         }
-        
+
         .status-badge {
             position: absolute;
             top: 1rem;
@@ -139,34 +139,34 @@
         .status-badge.coming-soon {
             background: var(--secondary-color);
         }
-        
+
         /* Dark mode 支援 */
         [data-theme="dark"] .tool-card {
             background: var(--card-bg);
             box-shadow: 0 4px 20px rgba(0,0,0,0.3);
         }
-        
+
         [data-theme="dark"] .tool-card:hover {
             box-shadow: 0 12px 40px rgba(255,255,255,0.1);
         }
-        
+
         [data-theme="dark"] .tool-card.coming-soon {
             background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-color) 100%);
         }
-        
+
         [data-theme="dark"] .tool-title {
             color: var(--text-color);
         }
-        
+
         [data-theme="dark"] .tool-description {
             color: var(--text-secondary);
         }
-        
+
         .status-badge.under-construction {
             background: #ff9800;
             box-shadow: 0 2px 8px rgba(255, 152, 0, 0.3);
         }
-        
+
         .tool-icon {
             font-size: 3.5rem;
             margin-bottom: 1.5rem;
@@ -174,7 +174,7 @@
             text-align: center;
             transition: transform 0.3s ease;
         }
-        
+
         .tool-title {
             font-size: 1.4rem;
             margin-bottom: 1rem;
@@ -183,7 +183,7 @@
             text-align: center;
             line-height: 1.3;
         }
-        
+
         .tool-description {
             color: #666;
             line-height: 1.6;
@@ -191,7 +191,7 @@
             margin: 0;
             font-size: 0.95rem;
         }
-        
+
         .tools-stats {
             display: flex;
             justify-content: center;
@@ -201,11 +201,11 @@
             background: linear-gradient(135deg, #f8f9ff 0%, #e8f0ff 100%);
             border-radius: 16px;
         }
-        
+
         .stat-item {
             text-align: center;
         }
-        
+
         .stat-number {
             display: block;
             font-size: 2.5rem;
@@ -213,83 +213,83 @@
             color: var(--primary-color);
             margin-bottom: 0.5rem;
         }
-        
+
         .stat-label {
             color: #666;
             font-size: 0.9rem;
             font-weight: 500;
         }
-        
+
         /* 簡化導航 */
         .nav a[href="#tools"] {
             display: none;
         }
-        
+
         @media (max-width: 768px) {
             .hero {
                 padding: 3rem 1.5rem;
                 margin-bottom: 3rem;
             }
-            
+
             .hero h1 {
                 font-size: 2.2rem;
             }
-            
+
             .hero p {
                 font-size: 1.1rem;
             }
-            
+
             .tools-section h2 {
                 font-size: 2rem;
                 margin-bottom: 2rem;
             }
-            
+
             .tools-grid {
                 grid-template-columns: 1fr;
                 gap: 1.5rem;
             }
-            
+
             .tool-card {
                 padding: 2rem 1.5rem;
             }
-            
+
             .tool-icon {
                 font-size: 3rem;
             }
-            
+
             .tool-title {
                 font-size: 1.2rem;
             }
-            
+
             .tools-stats {
                 flex-direction: column;
                 gap: 1.5rem;
                 margin: 2rem 0;
             }
-            
+
             .stat-number {
                 font-size: 2rem;
             }
         }
-        
+
         @media (max-width: 480px) {
             .hero {
                 padding: 2.5rem 1rem;
                 border-radius: 12px;
             }
-            
+
             .hero h1 {
                 font-size: 1.8rem;
             }
-            
+
             .hero p {
                 font-size: 1rem;
             }
-            
+
             .tools-grid {
                 gap: 1rem;
             }
-            
+
             .tool-card {
                 padding: 1.5rem;
             }
@@ -384,6 +384,12 @@
                         <div class="tool-icon">🔄</div>
                         <h3 class="tool-title" data-i18n="tool_macro_converter_title">巨集轉換器</h3>
                         <p class="tool-description" data-i18n="tool_macro_converter_desc">將 FF14 巨集在繁體中文、英文、日文之間轉換</p>
+                    </a>
+
+                    <a href="tools/weather-forecast/index.html" class="tool-card available">
+                        <div class="tool-icon">🌤️</div>
+                        <h3 class="tool-title" data-i18n="tool_weather_forecast_title">天氣預報</h3>
+                        <p class="tool-description" data-i18n="tool_weather_forecast_desc">查看艾歐澤亞各地區的天氣預報，搜尋特定天氣條件</p>
                     </a>
 
                     <div class="tool-card coming-soon">

--- a/tools/weather-forecast/index.html
+++ b/tools/weather-forecast/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>天氣預報 - FF14.tw</title>
+    <meta name="description" content="查看艾歐澤亞各地區的天氣預報，搜尋特定天氣條件，追蹤特殊事件">
+    <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="stylesheet" href="../../assets/css/common.css">
+    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
+    <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div id="header-placeholder" data-base-path="../../" data-tool-name="天氣預報" data-tool-name-key="weather_header"></div>
+    <noscript>
+        <nav style="padding: 1rem; background: #667eea; color: white; text-align: center;">
+            <a href="/" style="color: white; margin: 0 1rem;">首頁</a>
+            <a href="/copyright.html" style="color: white; margin: 0 1rem;">版權聲明</a>
+            <a href="https://github.com/hydai/ff14.tw" target="_blank" rel="noopener noreferrer" style="color: white; margin: 0 1rem;">GitHub</a>
+            <a href="/about.html" style="color: white; margin: 0 1rem;">關於</a>
+        </nav>
+    </noscript>
+
+    <main class="main">
+        <div class="container">
+            <h1 class="visually-hidden" data-i18n="weather_header">天氣預報</h1>
+
+            <!-- 目前時間顯示 -->
+            <div class="current-time-bar">
+                <div class="time-display">
+                    <span class="time-label" data-i18n="weather_current_et">目前 ET</span>
+                    <span class="time-value" id="currentET">--:--</span>
+                </div>
+                <div class="time-display">
+                    <span class="time-label" data-i18n="weather_current_lt">本地時間</span>
+                    <span class="time-value" id="currentLT">--:--</span>
+                </div>
+            </div>
+
+            <div class="tool-container weather-tool">
+                <!-- 左側：地區選擇 -->
+                <aside class="zone-selector-panel">
+                    <h2 class="panel-title" data-i18n="weather_select_zone">選擇地區</h2>
+                    <div class="zone-list" id="zoneList">
+                        <!-- 區域和地區按鈕將由 JavaScript 動態生成 -->
+                    </div>
+                </aside>
+
+                <!-- 右側：主要內容區 -->
+                <div class="main-content-panel">
+                    <!-- 沒有選擇地區時的提示 -->
+                    <div class="no-zone-selected" id="noZoneSelected">
+                        <div class="hint-icon">🗺️</div>
+                        <p data-i18n="weather_select_zone_hint">點擊地區按鈕開始查看天氣</p>
+                    </div>
+
+                    <!-- 選擇地區後的內容 -->
+                    <div class="zone-content" id="zoneContent" style="display: none;">
+                        <!-- 目前選擇的地區 -->
+                        <div class="selected-zone-header">
+                            <h2 id="selectedZoneName">--</h2>
+                            <button class="btn btn-sm btn-secondary" id="shareBtn" title="分享連結">
+                                <span class="btn-icon">🔗</span>
+                                <span data-i18n="weather_share">分享連結</span>
+                            </button>
+                        </div>
+
+                        <!-- 過濾器面板 -->
+                        <div class="filter-panel">
+                            <div class="filter-header">
+                                <h3 data-i18n="weather_filter_title">過濾條件</h3>
+                                <button class="btn btn-sm btn-outline-secondary" id="clearFiltersBtn" data-i18n="weather_clear_filters">清除過濾</button>
+                            </div>
+
+                            <!-- 目標天氣過濾 -->
+                            <div class="filter-group">
+                                <label data-i18n="weather_desired_weather">目標天氣</label>
+                                <div class="weather-tags" id="desiredWeatherTags">
+                                    <!-- 天氣標籤將由 JavaScript 動態生成 -->
+                                </div>
+                            </div>
+
+                            <!-- 前置天氣過濾 -->
+                            <div class="filter-group">
+                                <label data-i18n="weather_previous_weather">前置天氣</label>
+                                <div class="weather-tags" id="previousWeatherTags">
+                                    <!-- 天氣標籤將由 JavaScript 動態生成 -->
+                                </div>
+                            </div>
+
+                            <!-- 時間範圍過濾 -->
+                            <div class="filter-group">
+                                <label data-i18n="weather_time_range">艾歐澤亞時間範圍</label>
+                                <div class="time-range-selector">
+                                    <div class="time-grid" id="timeGrid">
+                                        <!-- 24 個時間格子將由 JavaScript 動態生成 -->
+                                    </div>
+                                    <div class="time-range-display">
+                                        <span id="timeRangeText">00:00 - 24:00</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- 結果區域 -->
+                        <div class="results-panel">
+                            <h3 id="resultsTitle" data-i18n="weather_timetable">天氣時刻表</h3>
+
+                            <!-- 載入中 -->
+                            <div class="loading" id="resultsLoading" style="display: none;">
+                                <div class="loading-spinner"></div>
+                                <p data-i18n="weather_loading">載入中...</p>
+                            </div>
+
+                            <!-- 結果表格 -->
+                            <div class="results-table-container" id="resultsContainer">
+                                <table class="results-table" id="resultsTable">
+                                    <thead>
+                                        <tr>
+                                            <th data-i18n="weather_col_local_time">本地時間</th>
+                                            <th data-i18n="weather_col_eorzea_time">ET 時間</th>
+                                            <th data-i18n="weather_col_weather">天氣</th>
+                                            <th data-i18n="weather_col_prev_weather">前置天氣</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="resultsBody">
+                                        <!-- 結果行將由 JavaScript 動態生成 -->
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <!-- 無結果 -->
+                            <div class="no-results" id="noResults" style="display: none;">
+                                <p data-i18n="weather_no_results">沒有符合條件的結果</p>
+                            </div>
+
+                            <!-- 顯示更多按鈕 -->
+                            <button class="btn btn-primary btn-block" id="showMoreBtn" style="display: none;" data-i18n="weather_show_more">顯示更多</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-placeholder" data-base-path="../../"></div>
+
+    <!-- Toast 通知 -->
+    <div class="toast" id="toast"></div>
+
+    <script src="../../assets/js/i18n/i18n-manager.js"></script>
+    <script src="../../assets/js/i18n/translations/common.js"></script>
+    <script src="../../assets/js/i18n/translations/tools/weather-forecast.js"></script>
+    <script src="../../assets/js/components/nav-template.js"></script>
+    <script src="../../assets/js/components/footer-template.js"></script>
+    <script src="../../assets/js/components/layout-loader.js"></script>
+    <script src="../../assets/js/common.js"></script>
+    <script src="../../assets/js/security-utils.js"></script>
+    <script src="zone-data.js"></script>
+    <script src="weather-calculator.js"></script>
+    <script src="weather-store.js"></script>
+    <script src="weather-search.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/weather-forecast/script.js
+++ b/tools/weather-forecast/script.js
@@ -306,7 +306,7 @@ class WeatherForecast {
             // End selection
             this.isSelectingTimeRange = false;
             const endHour = (hour + 1) % 25; // Make end exclusive
-            this.store.setTimeRange(this.timeRangeStart, endHour === 0 ? 24 : endHour);
+            this.store.setTimeRange(this.timeRangeStart, endHour);
             this.timeRangeStart = null;
         }
     }
@@ -333,11 +333,11 @@ class WeatherForecast {
             cell.classList.remove(WeatherForecast.CONSTANTS.CSS_CLASSES.IN_RANGE, WeatherForecast.CONSTANTS.CSS_CLASSES.SELECTED);
 
             if (start <= end) {
-                if (i >= start && i <= end) {
+                if (i >= start && i < end) {
                     cell.classList.add(WeatherForecast.CONSTANTS.CSS_CLASSES.IN_RANGE);
                 }
             } else {
-                if (i >= start || i <= end) {
+                if (i >= start || i < end) {
                     cell.classList.add(WeatherForecast.CONSTANTS.CSS_CLASSES.IN_RANGE);
                 }
             }

--- a/tools/weather-forecast/script.js
+++ b/tools/weather-forecast/script.js
@@ -1,0 +1,674 @@
+/**
+ * FF14 Weather Forecast - Main Controller
+ * Orchestrates all modules and handles UI interactions
+ */
+
+class WeatherForecast {
+    // Constants
+    static CONSTANTS = {
+        DEBOUNCE_DELAY: 300,
+        INITIAL_RESULTS: 24,
+        MAX_RESULTS: 200,
+        TIME_UPDATE_INTERVAL: 1000,
+        CSS_CLASSES: {
+            ACTIVE: 'active',
+            COLLAPSED: 'collapsed',
+            CURRENT: 'current-weather',
+            IN_RANGE: 'in-range',
+            SELECTED: 'selected'
+        }
+    };
+
+    constructor() {
+        // State
+        this.resultCount = WeatherForecast.CONSTANTS.INITIAL_RESULTS;
+        this.timeUpdateInterval = null;
+        this.timeRangeStart = null;
+        this.isSelectingTimeRange = false;
+
+        // Modules
+        this.store = new WeatherStore();
+        this.search = new WeatherSearch();
+
+        // DOM elements cache
+        this.elements = {
+            // Time display
+            currentET: document.getElementById('currentET'),
+            currentLT: document.getElementById('currentLT'),
+
+            // Zone selection
+            zoneList: document.getElementById('zoneList'),
+            noZoneSelected: document.getElementById('noZoneSelected'),
+            zoneContent: document.getElementById('zoneContent'),
+            selectedZoneName: document.getElementById('selectedZoneName'),
+
+            // Filters
+            desiredWeatherTags: document.getElementById('desiredWeatherTags'),
+            previousWeatherTags: document.getElementById('previousWeatherTags'),
+            timeGrid: document.getElementById('timeGrid'),
+            timeRangeText: document.getElementById('timeRangeText'),
+            clearFiltersBtn: document.getElementById('clearFiltersBtn'),
+
+            // Results
+            resultsTitle: document.getElementById('resultsTitle'),
+            resultsLoading: document.getElementById('resultsLoading'),
+            resultsContainer: document.getElementById('resultsContainer'),
+            resultsBody: document.getElementById('resultsBody'),
+            noResults: document.getElementById('noResults'),
+            showMoreBtn: document.getElementById('showMoreBtn'),
+
+            // Actions
+            shareBtn: document.getElementById('shareBtn'),
+            toast: document.getElementById('toast')
+        };
+
+        // Initialize
+        this.init();
+    }
+
+    /**
+     * Initialize the weather forecast tool
+     */
+    init() {
+        // Initialize store
+        this.store.init();
+
+        // Subscribe to state changes
+        this.store.subscribe((state, changeType) => this.handleStateChange(state, changeType));
+
+        // Build UI
+        this.buildZoneList();
+        this.buildTimeGrid();
+
+        // Set up event listeners
+        this.bindEvents();
+
+        // Start time updates
+        this.startTimeUpdates();
+
+        // Initial render based on URL hash
+        if (this.store.state.zoneId) {
+            this.showZoneContent();
+            this.renderWeatherTags();
+            this.updateTimeRangeUI();
+            this.renderResults();
+        }
+    }
+
+    /**
+     * Bind event listeners
+     */
+    bindEvents() {
+        // Zone selection (delegated)
+        this.elements.zoneList.addEventListener('click', (e) => this.handleZoneClick(e));
+
+        // Filter controls
+        this.elements.desiredWeatherTags.addEventListener('click', (e) => this.handleWeatherTagClick(e, 'desired'));
+        this.elements.previousWeatherTags.addEventListener('click', (e) => this.handleWeatherTagClick(e, 'previous'));
+        this.elements.clearFiltersBtn.addEventListener('click', () => this.handleClearFilters());
+
+        // Time grid
+        this.elements.timeGrid.addEventListener('click', (e) => this.handleTimeGridClick(e));
+        this.elements.timeGrid.addEventListener('mouseenter', (e) => this.handleTimeGridHover(e), true);
+
+        // Results
+        this.elements.showMoreBtn.addEventListener('click', () => this.handleShowMore());
+
+        // Share
+        this.elements.shareBtn.addEventListener('click', () => this.handleShare());
+    }
+
+    /**
+     * Build the zone list UI
+     */
+    buildZoneList() {
+        const grouped = WeatherZoneData.getZonesGroupedByRegion();
+        const fragment = document.createDocumentFragment();
+        const lang = window.i18n ? window.i18n.currentLang : 'zh';
+
+        for (const [regionId, zones] of Object.entries(grouped)) {
+            const regionInfo = WeatherZoneData.regions[regionId];
+            if (!regionInfo) continue;
+
+            const regionGroup = document.createElement('div');
+            regionGroup.className = 'region-group';
+
+            // Region header
+            const header = document.createElement('div');
+            header.className = 'region-header';
+            header.dataset.region = regionId;
+
+            const expandIcon = document.createElement('span');
+            expandIcon.className = 'expand-icon';
+            expandIcon.textContent = '▼';
+
+            const regionName = document.createElement('span');
+            regionName.textContent = regionInfo[lang] || regionInfo.zh;
+
+            header.appendChild(expandIcon);
+            header.appendChild(regionName);
+
+            // Zone buttons container
+            const buttonsContainer = document.createElement('div');
+            buttonsContainer.className = 'zone-buttons';
+
+            for (const zone of zones) {
+                const btn = document.createElement('button');
+                btn.className = 'zone-btn';
+                btn.dataset.zone = zone.id;
+                btn.textContent = zone[lang] || zone.zh;
+                buttonsContainer.appendChild(btn);
+            }
+
+            regionGroup.appendChild(header);
+            regionGroup.appendChild(buttonsContainer);
+            fragment.appendChild(regionGroup);
+        }
+
+        this.elements.zoneList.appendChild(fragment);
+    }
+
+    /**
+     * Build the time grid UI
+     */
+    buildTimeGrid() {
+        const fragment = document.createDocumentFragment();
+
+        for (let i = 0; i < 24; i++) {
+            const cell = document.createElement('div');
+            cell.className = 'time-cell';
+            cell.dataset.hour = i;
+            cell.textContent = String(i).padStart(2, '0');
+            fragment.appendChild(cell);
+        }
+
+        this.elements.timeGrid.appendChild(fragment);
+    }
+
+    /**
+     * Start time update interval
+     */
+    startTimeUpdates() {
+        this.updateTimeDisplay();
+        this.timeUpdateInterval = setInterval(() => {
+            this.updateTimeDisplay();
+        }, WeatherForecast.CONSTANTS.TIME_UPDATE_INTERVAL);
+    }
+
+    /**
+     * Update the current time display
+     */
+    updateTimeDisplay() {
+        const now = Date.now();
+
+        // Eorzea time
+        this.elements.currentET.textContent = WeatherCalculator.formatEorzeaTime(now);
+
+        // Local time
+        const localTime = new Date(now);
+        const hours = String(localTime.getHours()).padStart(2, '0');
+        const minutes = String(localTime.getMinutes()).padStart(2, '0');
+        this.elements.currentLT.textContent = `${hours}:${minutes}`;
+    }
+
+    /**
+     * Handle state changes from the store
+     */
+    handleStateChange(state, changeType) {
+        switch (changeType) {
+            case 'zone':
+                this.showZoneContent();
+                this.renderWeatherTags();
+                this.updateTimeRangeUI();
+                this.resultCount = WeatherForecast.CONSTANTS.INITIAL_RESULTS;
+                this.renderResults();
+                break;
+            case 'desiredWeathers':
+            case 'previousWeathers':
+                this.updateWeatherTagsUI();
+                this.resultCount = WeatherForecast.CONSTANTS.INITIAL_RESULTS;
+                this.renderResults();
+                break;
+            case 'timeRange':
+                this.updateTimeRangeUI();
+                this.resultCount = WeatherForecast.CONSTANTS.INITIAL_RESULTS;
+                this.renderResults();
+                break;
+            case 'clearFilters':
+                this.renderWeatherTags();
+                this.updateTimeRangeUI();
+                this.resultCount = WeatherForecast.CONSTANTS.INITIAL_RESULTS;
+                this.renderResults();
+                break;
+            case 'reset':
+                this.hideZoneContent();
+                break;
+        }
+    }
+
+    /**
+     * Handle zone button click
+     */
+    handleZoneClick(e) {
+        // Handle region header click (collapse/expand)
+        const header = e.target.closest('.region-header');
+        if (header) {
+            const group = header.closest('.region-group');
+            group.classList.toggle(WeatherForecast.CONSTANTS.CSS_CLASSES.COLLAPSED);
+            return;
+        }
+
+        // Handle zone button click
+        const btn = e.target.closest('.zone-btn');
+        if (btn) {
+            const zoneId = btn.dataset.zone;
+
+            // Update active state
+            const allBtns = this.elements.zoneList.querySelectorAll('.zone-btn');
+            allBtns.forEach(b => b.classList.remove(WeatherForecast.CONSTANTS.CSS_CLASSES.ACTIVE));
+            btn.classList.add(WeatherForecast.CONSTANTS.CSS_CLASSES.ACTIVE);
+
+            // Update store
+            this.store.setZone(zoneId);
+        }
+    }
+
+    /**
+     * Handle weather tag click
+     */
+    handleWeatherTagClick(e, type) {
+        const tag = e.target.closest('.weather-tag');
+        if (!tag) return;
+
+        const weather = tag.dataset.weather;
+        if (type === 'desired') {
+            this.store.toggleDesiredWeather(weather);
+        } else {
+            this.store.togglePreviousWeather(weather);
+        }
+    }
+
+    /**
+     * Handle time grid click
+     */
+    handleTimeGridClick(e) {
+        const cell = e.target.closest('.time-cell');
+        if (!cell) return;
+
+        const hour = parseInt(cell.dataset.hour, 10);
+
+        if (!this.isSelectingTimeRange) {
+            // Start selection
+            this.isSelectingTimeRange = true;
+            this.timeRangeStart = hour;
+            this.updateTimeGridPreview(hour, hour);
+        } else {
+            // End selection
+            this.isSelectingTimeRange = false;
+            const endHour = (hour + 1) % 25; // Make end exclusive
+            this.store.setTimeRange(this.timeRangeStart, endHour === 0 ? 24 : endHour);
+            this.timeRangeStart = null;
+        }
+    }
+
+    /**
+     * Handle time grid hover
+     */
+    handleTimeGridHover(e) {
+        if (!this.isSelectingTimeRange) return;
+
+        const cell = e.target.closest('.time-cell');
+        if (!cell) return;
+
+        const hour = parseInt(cell.dataset.hour, 10);
+        this.updateTimeGridPreview(this.timeRangeStart, hour);
+    }
+
+    /**
+     * Update time grid preview during selection
+     */
+    updateTimeGridPreview(start, end) {
+        const cells = this.elements.timeGrid.querySelectorAll('.time-cell');
+        cells.forEach((cell, i) => {
+            cell.classList.remove(WeatherForecast.CONSTANTS.CSS_CLASSES.IN_RANGE, WeatherForecast.CONSTANTS.CSS_CLASSES.SELECTED);
+
+            if (start <= end) {
+                if (i >= start && i <= end) {
+                    cell.classList.add(WeatherForecast.CONSTANTS.CSS_CLASSES.IN_RANGE);
+                }
+            } else {
+                if (i >= start || i <= end) {
+                    cell.classList.add(WeatherForecast.CONSTANTS.CSS_CLASSES.IN_RANGE);
+                }
+            }
+
+            if (i === start || i === end) {
+                cell.classList.add(WeatherForecast.CONSTANTS.CSS_CLASSES.SELECTED);
+            }
+        });
+    }
+
+    /**
+     * Handle clear filters button
+     */
+    handleClearFilters() {
+        this.store.clearFilters();
+    }
+
+    /**
+     * Handle show more button
+     */
+    handleShowMore() {
+        this.resultCount = Math.min(
+            this.resultCount * 2,
+            WeatherForecast.CONSTANTS.MAX_RESULTS
+        );
+        this.renderResults();
+    }
+
+    /**
+     * Handle share button
+     */
+    handleShare() {
+        const url = window.location.href;
+        navigator.clipboard.writeText(url).then(() => {
+            this.showToast(window.i18n ? window.i18n.t('weather_copied') : '已複製到剪貼簿');
+        });
+    }
+
+    /**
+     * Show zone content panel
+     */
+    showZoneContent() {
+        this.elements.noZoneSelected.style.display = 'none';
+        this.elements.zoneContent.style.display = 'block';
+
+        // Update zone name
+        const zone = this.store.getCurrentZone();
+        if (zone) {
+            const lang = window.i18n ? window.i18n.currentLang : 'zh';
+            this.elements.selectedZoneName.textContent = zone[lang] || zone.zh;
+        }
+    }
+
+    /**
+     * Hide zone content panel
+     */
+    hideZoneContent() {
+        this.elements.noZoneSelected.style.display = 'flex';
+        this.elements.zoneContent.style.display = 'none';
+
+        // Clear active zone button
+        const allBtns = this.elements.zoneList.querySelectorAll('.zone-btn');
+        allBtns.forEach(b => b.classList.remove(WeatherForecast.CONSTANTS.CSS_CLASSES.ACTIVE));
+    }
+
+    /**
+     * Render weather tags for the current zone
+     */
+    renderWeatherTags() {
+        const weathers = this.store.getAvailableWeathers();
+        const lang = window.i18n ? window.i18n.currentLang : 'zh';
+
+        // Clear existing tags
+        this.elements.desiredWeatherTags.textContent = '';
+        this.elements.previousWeatherTags.textContent = '';
+
+        for (const weather of weathers) {
+            const info = WeatherZoneData.getWeatherInfo(weather);
+            if (!info) continue;
+
+            // Create tag for desired weathers
+            const desiredTag = this.createWeatherTag(weather, info, lang);
+            this.elements.desiredWeatherTags.appendChild(desiredTag);
+
+            // Create tag for previous weathers
+            const previousTag = this.createWeatherTag(weather, info, lang);
+            this.elements.previousWeatherTags.appendChild(previousTag);
+        }
+
+        this.updateWeatherTagsUI();
+    }
+
+    /**
+     * Create a weather tag element
+     */
+    createWeatherTag(weather, info, lang) {
+        const tag = document.createElement('button');
+        tag.className = 'weather-tag';
+        tag.dataset.weather = weather;
+
+        const icon = document.createElement('span');
+        icon.className = 'weather-icon';
+        icon.textContent = info.icon;
+
+        const name = document.createElement('span');
+        name.className = 'weather-name';
+        name.textContent = info[lang] || info.zh;
+
+        tag.appendChild(icon);
+        tag.appendChild(name);
+
+        return tag;
+    }
+
+    /**
+     * Update weather tags UI to reflect current selections
+     */
+    updateWeatherTagsUI() {
+        // Update desired weather tags
+        const desiredTags = this.elements.desiredWeatherTags.querySelectorAll('.weather-tag');
+        desiredTags.forEach(tag => {
+            const weather = tag.dataset.weather;
+            tag.classList.toggle(
+                WeatherForecast.CONSTANTS.CSS_CLASSES.ACTIVE,
+                this.store.state.desiredWeathers.has(weather)
+            );
+        });
+
+        // Update previous weather tags
+        const previousTags = this.elements.previousWeatherTags.querySelectorAll('.weather-tag');
+        previousTags.forEach(tag => {
+            const weather = tag.dataset.weather;
+            tag.classList.toggle(
+                WeatherForecast.CONSTANTS.CSS_CLASSES.ACTIVE,
+                this.store.state.previousWeathers.has(weather)
+            );
+        });
+    }
+
+    /**
+     * Update time range UI
+     */
+    updateTimeRangeUI() {
+        const { beginHour, endHour } = this.store.state;
+
+        // Update grid cells
+        const cells = this.elements.timeGrid.querySelectorAll('.time-cell');
+        cells.forEach((cell, i) => {
+            cell.classList.remove(
+                WeatherForecast.CONSTANTS.CSS_CLASSES.SELECTED,
+                WeatherForecast.CONSTANTS.CSS_CLASSES.IN_RANGE
+            );
+
+            if (WeatherCalculator.isInTimeRange(i, beginHour, endHour)) {
+                cell.classList.add(WeatherForecast.CONSTANTS.CSS_CLASSES.IN_RANGE);
+            }
+        });
+
+        // Update text display
+        const beginText = String(beginHour).padStart(2, '0') + ':00';
+        const endText = String(endHour).padStart(2, '0') + ':00';
+        this.elements.timeRangeText.textContent = `${beginText} - ${endText}`;
+    }
+
+    /**
+     * Render search results
+     */
+    renderResults() {
+        const zone = this.store.getCurrentZone();
+        if (!zone) return;
+
+        // Show loading
+        this.elements.resultsLoading.style.display = 'block';
+        this.elements.resultsContainer.style.display = 'none';
+        this.elements.noResults.style.display = 'none';
+        this.elements.showMoreBtn.style.display = 'none';
+
+        // Use requestAnimationFrame to avoid blocking
+        requestAnimationFrame(() => {
+            let results;
+
+            if (this.store.hasActiveFilters()) {
+                // Search with filters
+                results = this.search.search(zone, {
+                    desiredWeathers: this.store.state.desiredWeathers,
+                    previousWeathers: this.store.state.previousWeathers,
+                    beginHour: this.store.state.beginHour,
+                    endHour: this.store.state.endHour,
+                    event: this.store.state.event
+                }, Date.now(), this.resultCount);
+
+                // Update title
+                this.elements.resultsTitle.textContent = window.i18n
+                    ? window.i18n.t('weather_results')
+                    : '搜尋結果';
+            } else {
+                // Timetable view (no filters)
+                results = this.search.getUpcomingWeather(zone, Date.now(), this.resultCount);
+
+                // Update title
+                this.elements.resultsTitle.textContent = window.i18n
+                    ? window.i18n.t('weather_timetable')
+                    : '天氣時刻表';
+            }
+
+            // Hide loading
+            this.elements.resultsLoading.style.display = 'none';
+
+            if (results.length === 0) {
+                this.elements.noResults.style.display = 'block';
+                return;
+            }
+
+            // Render results
+            this.renderResultsTable(results);
+            this.elements.resultsContainer.style.display = 'block';
+
+            // Show "show more" button if there might be more results
+            if (results.length >= this.resultCount && this.resultCount < WeatherForecast.CONSTANTS.MAX_RESULTS) {
+                this.elements.showMoreBtn.style.display = 'block';
+            }
+        });
+    }
+
+    /**
+     * Render results table
+     */
+    renderResultsTable(results) {
+        const lang = window.i18n ? window.i18n.currentLang : 'zh';
+        const fragment = document.createDocumentFragment();
+        const now = Date.now();
+
+        for (const result of results) {
+            const row = document.createElement('tr');
+
+            // Check if this is the current weather period
+            if (result.start <= now && result.end > now) {
+                row.classList.add(WeatherForecast.CONSTANTS.CSS_CLASSES.CURRENT);
+            }
+
+            // Local time
+            const localTimeCell = document.createElement('td');
+            localTimeCell.textContent = WeatherCalculator.formatLocalTime(result.start, true);
+            row.appendChild(localTimeCell);
+
+            // Eorzea time
+            const etCell = document.createElement('td');
+            const etHours = String(result.eorzeaTime.hours).padStart(2, '0');
+            etCell.textContent = `${etHours}:00`;
+            row.appendChild(etCell);
+
+            // Current weather
+            const weatherCell = document.createElement('td');
+            const weatherInfo = WeatherZoneData.getWeatherInfo(result.weather);
+            if (weatherInfo) {
+                const weatherSpan = document.createElement('span');
+                weatherSpan.className = 'weather-cell';
+
+                const icon = document.createElement('span');
+                icon.className = 'weather-icon';
+                icon.textContent = weatherInfo.icon;
+
+                const name = document.createElement('span');
+                name.textContent = weatherInfo[lang] || weatherInfo.zh;
+
+                weatherSpan.appendChild(icon);
+                weatherSpan.appendChild(name);
+                weatherCell.appendChild(weatherSpan);
+            } else {
+                weatherCell.textContent = result.weather;
+            }
+            row.appendChild(weatherCell);
+
+            // Previous weather
+            const prevWeatherCell = document.createElement('td');
+            if (result.previousWeather) {
+                const prevInfo = WeatherZoneData.getWeatherInfo(result.previousWeather);
+                if (prevInfo) {
+                    const prevSpan = document.createElement('span');
+                    prevSpan.className = 'weather-cell';
+
+                    const prevIcon = document.createElement('span');
+                    prevIcon.className = 'weather-icon';
+                    prevIcon.textContent = prevInfo.icon;
+
+                    const prevName = document.createElement('span');
+                    prevName.textContent = prevInfo[lang] || prevInfo.zh;
+
+                    prevSpan.appendChild(prevIcon);
+                    prevSpan.appendChild(prevName);
+                    prevWeatherCell.appendChild(prevSpan);
+                } else {
+                    prevWeatherCell.textContent = result.previousWeather;
+                }
+            } else {
+                prevWeatherCell.textContent = '-';
+            }
+            row.appendChild(prevWeatherCell);
+
+            fragment.appendChild(row);
+        }
+
+        // Clear and append
+        this.elements.resultsBody.textContent = '';
+        this.elements.resultsBody.appendChild(fragment);
+    }
+
+    /**
+     * Show toast notification
+     */
+    showToast(message) {
+        this.elements.toast.textContent = message;
+        this.elements.toast.classList.add('show');
+
+        setTimeout(() => {
+            this.elements.toast.classList.remove('show');
+        }, 2000);
+    }
+
+    /**
+     * Cleanup
+     */
+    destroy() {
+        if (this.timeUpdateInterval) {
+            clearInterval(this.timeUpdateInterval);
+        }
+        this.store.destroy();
+    }
+}
+
+// Initialize when DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+    window.weatherForecast = new WeatherForecast();
+});

--- a/tools/weather-forecast/script.js
+++ b/tools/weather-forecast/script.js
@@ -124,7 +124,7 @@ class WeatherForecast {
     buildZoneList() {
         const grouped = WeatherZoneData.getZonesGroupedByRegion();
         const fragment = document.createDocumentFragment();
-        const lang = window.i18n ? window.i18n.currentLang : 'zh';
+        const lang = window.i18n ? window.i18n.currentLanguage : 'zh';
 
         for (const [regionId, zones] of Object.entries(grouped)) {
             const regionInfo = WeatherZoneData.regions[regionId];
@@ -372,7 +372,7 @@ class WeatherForecast {
     handleShare() {
         const url = window.location.href;
         navigator.clipboard.writeText(url).then(() => {
-            this.showToast(window.i18n ? window.i18n.t('weather_copied') : '已複製到剪貼簿');
+            this.showToast(window.i18n ? window.i18n.getText('weather_copied') : '已複製到剪貼簿');
         });
     }
 
@@ -386,7 +386,7 @@ class WeatherForecast {
         // Update zone name
         const zone = this.store.getCurrentZone();
         if (zone) {
-            const lang = window.i18n ? window.i18n.currentLang : 'zh';
+            const lang = window.i18n ? window.i18n.currentLanguage : 'zh';
             this.elements.selectedZoneName.textContent = zone[lang] || zone.zh;
         }
     }
@@ -408,7 +408,7 @@ class WeatherForecast {
      */
     renderWeatherTags() {
         const weathers = this.store.getAvailableWeathers();
-        const lang = window.i18n ? window.i18n.currentLang : 'zh';
+        const lang = window.i18n ? window.i18n.currentLanguage : 'zh';
 
         // Clear existing tags
         this.elements.desiredWeatherTags.textContent = '';
@@ -531,7 +531,7 @@ class WeatherForecast {
 
                 // Update title
                 this.elements.resultsTitle.textContent = window.i18n
-                    ? window.i18n.t('weather_results')
+                    ? window.i18n.getText('weather_results')
                     : '搜尋結果';
             } else {
                 // Timetable view (no filters)
@@ -539,7 +539,7 @@ class WeatherForecast {
 
                 // Update title
                 this.elements.resultsTitle.textContent = window.i18n
-                    ? window.i18n.t('weather_timetable')
+                    ? window.i18n.getText('weather_timetable')
                     : '天氣時刻表';
             }
 
@@ -566,7 +566,7 @@ class WeatherForecast {
      * Render results table
      */
     renderResultsTable(results) {
-        const lang = window.i18n ? window.i18n.currentLang : 'zh';
+        const lang = window.i18n ? window.i18n.currentLanguage : 'zh';
         const fragment = document.createDocumentFragment();
         const now = Date.now();
 

--- a/tools/weather-forecast/script.js
+++ b/tools/weather-forecast/script.js
@@ -348,7 +348,7 @@ class WeatherForecast {
         } else {
             // End selection
             this.isSelectingTimeRange = false;
-            const endHour = (hour + 1) % 25; // Make end exclusive
+            const endHour = hour + 1; // Make end exclusive (hour is 0-23, so endHour is 1-24)
             this.store.setTimeRange(this.timeRangeStart, endHour);
             this.timeRangeStart = null;
         }

--- a/tools/weather-forecast/style.css
+++ b/tools/weather-forecast/style.css
@@ -1,0 +1,529 @@
+/* ===================================
+   天氣預報工具樣式 (Weather Forecast Tool)
+   =================================== */
+
+/* 目前時間條 */
+.current-time-bar {
+    display: flex;
+    justify-content: center;
+    gap: 3rem;
+    padding: 1rem;
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+    border-radius: 12px;
+    margin-bottom: 1.5rem;
+    color: white;
+}
+
+.time-display {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.time-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    opacity: 0.9;
+}
+
+.time-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    font-family: 'Consolas', 'Monaco', monospace;
+}
+
+/* 工具容器 */
+.weather-tool {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 1.5rem;
+    min-height: 600px;
+}
+
+/* 左側地區選擇面板 */
+.zone-selector-panel {
+    background: var(--card-bg, white);
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    overflow-y: auto;
+    max-height: calc(100vh - 200px);
+}
+
+.panel-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--border-color, #dee2e6);
+}
+
+/* 區域群組 */
+.region-group {
+    margin-bottom: 1rem;
+}
+
+.region-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    cursor: pointer;
+    border-radius: 6px;
+    font-weight: 500;
+    font-size: 0.9rem;
+    color: var(--text-secondary, #6c757d);
+    transition: background-color 0.2s ease;
+}
+
+.region-header:hover {
+    background-color: var(--gray-100, #f8f9fa);
+}
+
+.region-header .expand-icon {
+    transition: transform 0.2s ease;
+}
+
+.region-group.collapsed .expand-icon {
+    transform: rotate(-90deg);
+}
+
+.region-group.collapsed .zone-buttons {
+    display: none;
+}
+
+/* 地區按鈕 */
+.zone-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding-left: 1rem;
+}
+
+.zone-btn {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+    text-align: left;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    color: var(--text-color, #212529);
+}
+
+.zone-btn:hover {
+    background-color: var(--gray-100, #f8f9fa);
+    border-color: var(--border-color, #dee2e6);
+}
+
+.zone-btn.active {
+    background-color: var(--primary-color, #4a90e2);
+    color: white;
+    border-color: var(--primary-color, #4a90e2);
+}
+
+/* 右側主要內容面板 */
+.main-content-panel {
+    background: var(--card-bg, white);
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+/* 無選擇提示 */
+.no-zone-selected {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 400px;
+    color: var(--text-secondary, #6c757d);
+}
+
+.hint-icon {
+    font-size: 4rem;
+    margin-bottom: 1rem;
+    opacity: 0.6;
+}
+
+.no-zone-selected p {
+    font-size: 1.1rem;
+}
+
+/* 選擇地區後的頭部 */
+.selected-zone-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 2px solid var(--border-color, #dee2e6);
+}
+
+.selected-zone-header h2 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+/* 過濾器面板 */
+.filter-panel {
+    background: var(--gray-50, #f8f9fa);
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.filter-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.filter-header h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.filter-group {
+    margin-bottom: 1rem;
+}
+
+.filter-group:last-child {
+    margin-bottom: 0;
+}
+
+.filter-group label {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-secondary, #6c757d);
+    margin-bottom: 0.5rem;
+}
+
+/* 天氣標籤 */
+.weather-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.weather-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.85rem;
+    background: white;
+    border: 2px solid var(--border-color, #dee2e6);
+    border-radius: 20px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    color: var(--text-color, #212529);
+}
+
+.weather-tag:hover {
+    border-color: var(--primary-color, #4a90e2);
+    background-color: var(--primary-light, #e8f0ff);
+}
+
+.weather-tag.active {
+    background-color: var(--primary-color, #4a90e2);
+    border-color: var(--primary-color, #4a90e2);
+    color: white;
+}
+
+.weather-tag .weather-icon {
+    font-size: 1rem;
+}
+
+/* 時間範圍選擇器 */
+.time-range-selector {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.time-grid {
+    display: grid;
+    grid-template-columns: repeat(24, 1fr);
+    gap: 2px;
+    background: var(--border-color, #dee2e6);
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.time-cell {
+    padding: 0.5rem 0;
+    text-align: center;
+    font-size: 0.7rem;
+    background: white;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+    user-select: none;
+}
+
+.time-cell:hover {
+    background-color: var(--gray-100, #f8f9fa);
+}
+
+.time-cell.selected {
+    background-color: var(--primary-color, #4a90e2);
+    color: white;
+}
+
+.time-cell.in-range {
+    background-color: var(--primary-light, #cce0ff);
+}
+
+.time-range-display {
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--text-secondary, #6c757d);
+}
+
+/* 結果面板 */
+.results-panel h3 {
+    margin: 0 0 1rem 0;
+    font-size: 1.1rem;
+}
+
+.results-table-container {
+    overflow-x: auto;
+}
+
+.results-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.results-table th,
+.results-table td {
+    padding: 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color, #dee2e6);
+}
+
+.results-table th {
+    background: var(--gray-50, #f8f9fa);
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--text-secondary, #6c757d);
+    white-space: nowrap;
+}
+
+.results-table tbody tr:hover {
+    background-color: var(--gray-50, #f8f9fa);
+}
+
+.results-table tbody tr.current-weather {
+    background-color: var(--primary-light, #e8f0ff);
+}
+
+.results-table tbody tr.current-weather td:first-child::before {
+    content: '▶ ';
+    color: var(--primary-color, #4a90e2);
+}
+
+/* 天氣單元格 */
+.weather-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.weather-cell .weather-icon {
+    font-size: 1.1rem;
+}
+
+/* 無結果 */
+.no-results {
+    text-align: center;
+    padding: 3rem;
+    color: var(--text-secondary, #6c757d);
+}
+
+/* 顯示更多按鈕 */
+#showMoreBtn {
+    margin-top: 1rem;
+}
+
+/* Toast 樣式覆寫 */
+.toast {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 12px 24px;
+    border-radius: 8px;
+    background: #333;
+    color: white;
+    font-size: 0.9rem;
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s ease;
+    z-index: 9999;
+}
+
+.toast.show {
+    opacity: 1;
+    visibility: visible;
+}
+
+/* Dark Mode 支援 */
+[data-theme="dark"] .zone-selector-panel,
+[data-theme="dark"] .main-content-panel {
+    background: var(--card-bg);
+}
+
+[data-theme="dark"] .region-header:hover {
+    background-color: var(--dark-gray-700, #374151);
+}
+
+[data-theme="dark"] .zone-btn:hover {
+    background-color: var(--dark-gray-700, #374151);
+    border-color: var(--dark-border-color, #4b5563);
+}
+
+[data-theme="dark"] .filter-panel {
+    background: var(--dark-gray-800, #1f2937);
+}
+
+[data-theme="dark"] .weather-tag {
+    background: var(--dark-gray-800, #1f2937);
+    border-color: var(--dark-border-color, #4b5563);
+    color: var(--dark-text-color, #e5e7eb);
+}
+
+[data-theme="dark"] .weather-tag:hover {
+    background-color: var(--dark-gray-700, #374151);
+}
+
+[data-theme="dark"] .weather-tag.active {
+    background-color: var(--primary-color, #4a90e2);
+    border-color: var(--primary-color, #4a90e2);
+    color: white;
+}
+
+[data-theme="dark"] .time-cell {
+    background: var(--dark-gray-800, #1f2937);
+    color: var(--dark-text-color, #e5e7eb);
+}
+
+[data-theme="dark"] .time-cell:hover {
+    background-color: var(--dark-gray-700, #374151);
+}
+
+[data-theme="dark"] .time-cell.in-range {
+    background-color: rgba(74, 144, 226, 0.3);
+}
+
+[data-theme="dark"] .time-grid {
+    background: var(--dark-border-color, #4b5563);
+}
+
+[data-theme="dark"] .results-table th {
+    background: var(--dark-gray-800, #1f2937);
+}
+
+[data-theme="dark"] .results-table tbody tr:hover {
+    background-color: var(--dark-gray-800, #1f2937);
+}
+
+[data-theme="dark"] .results-table tbody tr.current-weather {
+    background-color: rgba(74, 144, 226, 0.2);
+}
+
+/* 響應式設計 */
+@media (max-width: 992px) {
+    .weather-tool {
+        grid-template-columns: 1fr;
+    }
+
+    .zone-selector-panel {
+        max-height: none;
+    }
+
+    .zone-buttons {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .zone-btn {
+        flex: 0 0 auto;
+    }
+}
+
+@media (max-width: 768px) {
+    .current-time-bar {
+        gap: 2rem;
+        padding: 0.75rem;
+    }
+
+    .time-value {
+        font-size: 1.25rem;
+    }
+
+    .main-content-panel {
+        padding: 1rem;
+    }
+
+    .selected-zone-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+
+    .time-grid {
+        grid-template-columns: repeat(12, 1fr);
+    }
+
+    .time-cell {
+        padding: 0.375rem 0;
+        font-size: 0.65rem;
+    }
+
+    .results-table {
+        font-size: 0.8rem;
+    }
+
+    .results-table th,
+    .results-table td {
+        padding: 0.5rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .current-time-bar {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .time-display {
+        flex-direction: row;
+        gap: 0.5rem;
+    }
+
+    .weather-tags {
+        gap: 0.375rem;
+    }
+
+    .weather-tag {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.75rem;
+    }
+
+    .time-grid {
+        grid-template-columns: repeat(8, 1fr);
+    }
+
+    /* 隱藏前置天氣列以節省空間 */
+    .results-table th:nth-child(4),
+    .results-table td:nth-child(4) {
+        display: none;
+    }
+}

--- a/tools/weather-forecast/weather-calculator.js
+++ b/tools/weather-forecast/weather-calculator.js
@@ -1,0 +1,281 @@
+/**
+ * FF14 Weather Forecast - Weather Calculator
+ * Core algorithm for calculating deterministic weather in FFXIV
+ */
+
+const WeatherCalculator = {
+    // Constants
+    EORZEA_HOUR_MS: 175000,           // ~2.917 real minutes per Eorzea hour
+    EORZEA_DAY_MS: 4200000,           // ~70 real minutes per Eorzea day
+    WEATHER_DURATION_MS: 1400000,     // ~23.33 real minutes (8 Eorzea hours)
+    WEATHER_PERIODS: [0, 8, 16],      // ET hours when weather changes
+
+    /**
+     * Calculate the forecast target value (0-99) for a given timestamp
+     * This is the core algorithm reverse-engineered from the game
+     * @param {number} timestamp - Unix timestamp in milliseconds
+     * @returns {number} Forecast target value (0-99)
+     */
+    calculateForecastTarget(timestamp) {
+        // Convert to seconds
+        const unix = Math.trunc(timestamp / 1000);
+
+        // Calculate the bell (Eorzea hour, 175 seconds each)
+        const bell = Math.trunc(unix / 175);
+
+        // Calculate increment (which weather period: 0, 8, or 16)
+        // Weather changes at 00:00, 08:00, and 16:00 ET
+        const increment = (bell + 8 - (bell % 8)) % 24;
+
+        // Calculate total Eorzea days
+        const totalDays = Math.trunc(unix / 4200) >>> 0;
+
+        // Calculate base value for hashing
+        const calcBase = totalDays * 0x64 + increment;
+
+        // Two-step hash function
+        const step1 = ((calcBase << 0xB) ^ calcBase) >>> 0;
+        const step2 = ((step1 >>> 8) ^ step1) >>> 0;
+
+        // Return value in range 0-99
+        return step2 % 0x64;
+    },
+
+    /**
+     * Get weather for a zone at a specific timestamp
+     * @param {object} zone - Zone object with weatherTable
+     * @param {number} timestamp - Unix timestamp in milliseconds
+     * @returns {string} Weather name
+     */
+    getWeatherForZone(zone, timestamp) {
+        const target = this.calculateForecastTarget(timestamp);
+        return this.getWeatherFromTable(zone.weatherTable, target);
+    },
+
+    /**
+     * Get weather from a weather table based on target value
+     * @param {array} weatherTable - Weather table array
+     * @param {number} target - Target value (0-99)
+     * @returns {string} Weather name
+     */
+    getWeatherFromTable(weatherTable, target) {
+        // Weather table format: [weather1, chance1, weather2, chance2, ..., weatherN]
+        // Chances are cumulative thresholds
+        for (let i = 0; i < weatherTable.length - 1; i += 2) {
+            const weather = weatherTable[i];
+            const threshold = weatherTable[i + 1];
+            if (target < threshold) {
+                return weather;
+            }
+        }
+        // Return last weather if target exceeds all thresholds
+        return weatherTable[weatherTable.length - 1];
+    },
+
+    /**
+     * Get the start time of the current weather period
+     * @param {number} timestamp - Unix timestamp in milliseconds
+     * @returns {number} Start timestamp of the weather period
+     */
+    getWeatherPeriodStart(timestamp) {
+        const unix = Math.trunc(timestamp / 1000);
+        const bell = Math.trunc(unix / 175);
+        const periodBell = bell - (bell % 8);
+        return periodBell * 175 * 1000;
+    },
+
+    /**
+     * Get the start time of the next weather period
+     * @param {number} timestamp - Unix timestamp in milliseconds
+     * @returns {number} Start timestamp of the next weather period
+     */
+    getNextWeatherPeriodStart(timestamp) {
+        return this.getWeatherPeriodStart(timestamp) + this.WEATHER_DURATION_MS;
+    },
+
+    /**
+     * Generate weather forecast for a zone
+     * @param {object} zone - Zone object with weatherTable
+     * @param {number} startTime - Start timestamp (default: now)
+     * @param {number} periods - Number of weather periods to forecast (default: 12)
+     * @returns {array} Array of {start, end, weather, eorzeaTime} objects
+     */
+    getForecast(zone, startTime = Date.now(), periods = 12) {
+        const forecast = [];
+        let time = this.getWeatherPeriodStart(startTime);
+
+        for (let i = 0; i < periods; i++) {
+            const weather = this.getWeatherForZone(zone, time);
+            const end = time + this.WEATHER_DURATION_MS;
+            const eorzeaTime = this.getEorzeaTime(time);
+
+            forecast.push({
+                start: time,
+                end: end,
+                weather: weather,
+                eorzeaTime: eorzeaTime
+            });
+
+            time = end;
+        }
+
+        return forecast;
+    },
+
+    /**
+     * Get current Eorzea time
+     * @param {number} timestamp - Unix timestamp in milliseconds (default: now)
+     * @returns {object} {hours, minutes, totalMinutes, bell, day}
+     */
+    getEorzeaTime(timestamp = Date.now()) {
+        const unix = Math.trunc(timestamp / 1000);
+
+        // Eorzea time calculation
+        // 1 Eorzea day = 70 real minutes = 4200 real seconds
+        // 1 Eorzea hour = 175 real seconds
+        // 1 Eorzea minute = ~2.917 real seconds
+
+        const eorzeaSeconds = unix * (1440 / 70); // Convert to Eorzea seconds
+        const eorzeaMinutes = Math.trunc(eorzeaSeconds / 60);
+        const totalMinutes = eorzeaMinutes % (24 * 60);
+        const hours = Math.trunc(totalMinutes / 60);
+        const minutes = totalMinutes % 60;
+
+        // Bell is the Eorzea hour (0-23)
+        const bell = hours;
+
+        // Day number (for debugging)
+        const day = Math.trunc(eorzeaMinutes / (24 * 60));
+
+        return {
+            hours: hours,
+            minutes: minutes,
+            totalMinutes: totalMinutes,
+            bell: bell,
+            day: day
+        };
+    },
+
+    /**
+     * Format Eorzea time as string
+     * @param {number} timestamp - Unix timestamp in milliseconds (default: now)
+     * @returns {string} Formatted time string "HH:MM"
+     */
+    formatEorzeaTime(timestamp = Date.now()) {
+        const et = this.getEorzeaTime(timestamp);
+        const hours = String(et.hours).padStart(2, '0');
+        const minutes = String(et.minutes).padStart(2, '0');
+        return `${hours}:${minutes}`;
+    },
+
+    /**
+     * Format local time as string
+     * @param {number} timestamp - Unix timestamp in milliseconds
+     * @param {boolean} includeDate - Include date in output
+     * @returns {string} Formatted time string
+     */
+    formatLocalTime(timestamp, includeDate = false) {
+        const date = new Date(timestamp);
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+
+        if (includeDate) {
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            return `${month}/${day} ${hours}:${minutes}`;
+        }
+
+        return `${hours}:${minutes}`;
+    },
+
+    /**
+     * Format duration in minutes
+     * @param {number} durationMs - Duration in milliseconds
+     * @returns {string} Formatted duration string
+     */
+    formatDuration(durationMs) {
+        const minutes = Math.round(durationMs / 60000);
+        if (minutes >= 60) {
+            const hours = Math.floor(minutes / 60);
+            const mins = minutes % 60;
+            if (mins === 0) {
+                return `${hours}h`;
+            }
+            return `${hours}h ${mins}m`;
+        }
+        return `${minutes}m`;
+    },
+
+    /**
+     * Calculate time until a specific Eorzea hour
+     * @param {number} targetHour - Target Eorzea hour (0-23)
+     * @param {number} timestamp - Current timestamp (default: now)
+     * @returns {number} Milliseconds until target hour
+     */
+    getTimeUntilEorzeaHour(targetHour, timestamp = Date.now()) {
+        const currentET = this.getEorzeaTime(timestamp);
+        let hoursUntil = targetHour - currentET.hours;
+        if (hoursUntil <= 0) {
+            hoursUntil += 24;
+        }
+        // Also account for current minutes
+        const minutesUntil = hoursUntil * 60 - currentET.minutes;
+        return minutesUntil * this.EORZEA_HOUR_MS / 60;
+    },
+
+    /**
+     * Check if an Eorzea time is within a range (supports wrap-around)
+     * @param {number} hour - Eorzea hour to check (0-23)
+     * @param {number} beginHour - Range start hour (0-23)
+     * @param {number} endHour - Range end hour (0-23, exclusive)
+     * @returns {boolean} True if hour is within range
+     */
+    isInTimeRange(hour, beginHour, endHour) {
+        if (beginHour === endHour) {
+            return true; // Full 24 hours
+        }
+
+        if (beginHour < endHour) {
+            // Normal range (e.g., 8-16)
+            return hour >= beginHour && hour < endHour;
+        } else {
+            // Wrap-around range (e.g., 22-6)
+            return hour >= beginHour || hour < endHour;
+        }
+    },
+
+    /**
+     * Get the weather period index (0, 1, or 2) for an Eorzea hour
+     * @param {number} eorzeaHour - Eorzea hour (0-23)
+     * @returns {number} Weather period index
+     */
+    getWeatherPeriodIndex(eorzeaHour) {
+        if (eorzeaHour >= 16) return 2;
+        if (eorzeaHour >= 8) return 1;
+        return 0;
+    },
+
+    /**
+     * Get all weather periods that overlap with a time range
+     * @param {number} beginHour - Range start hour (0-23)
+     * @param {number} endHour - Range end hour (0-23)
+     * @returns {array} Array of weather period start hours [0, 8, 16]
+     */
+    getOverlappingWeatherPeriods(beginHour, endHour) {
+        const periods = [];
+        for (const period of this.WEATHER_PERIODS) {
+            const periodEnd = (period + 8) % 24;
+            // Check if any part of this period overlaps with the range
+            for (let h = period; h < period + 8; h++) {
+                if (this.isInTimeRange(h % 24, beginHour, endHour)) {
+                    periods.push(period);
+                    break;
+                }
+            }
+        }
+        return periods;
+    }
+};
+
+// Export for use in other modules
+window.WeatherCalculator = WeatherCalculator;

--- a/tools/weather-forecast/weather-search.js
+++ b/tools/weather-forecast/weather-search.js
@@ -1,0 +1,347 @@
+/**
+ * FF14 Weather Forecast - Weather Search Engine
+ * Filters and searches for specific weather conditions
+ */
+
+class WeatherSearch {
+    /**
+     * Create a new WeatherSearch instance
+     */
+    constructor() {
+        // Default search parameters
+        this.defaultDays = 60;
+        this.maxResults = 100;
+    }
+
+    /**
+     * Search for weather windows matching the given criteria
+     * @param {object} zone - Zone object with weatherTable
+     * @param {object} filters - Filter criteria
+     * @param {Set} filters.desiredWeathers - Set of desired weather names
+     * @param {Set} filters.previousWeathers - Set of required previous weather names
+     * @param {number} filters.beginHour - Start of ET time range (0-23)
+     * @param {number} filters.endHour - End of ET time range (0-24)
+     * @param {string} filters.event - Special event name (optional)
+     * @param {number} startTime - Search start timestamp (default: now)
+     * @param {number} maxResults - Maximum results to return
+     * @returns {array} Array of match objects
+     */
+    search(zone, filters, startTime = Date.now(), maxResults = this.maxResults) {
+        if (!zone || !filters) {
+            return [];
+        }
+
+        const calc = window.WeatherCalculator;
+        const results = [];
+        const searchDuration = this.defaultDays * 24 * 60 * 60 * 1000; // days in ms
+        const endTime = startTime + searchDuration;
+
+        // Get weather periods within search range
+        let time = calc.getWeatherPeriodStart(startTime);
+
+        // Track previous weather for transition checks
+        let previousWeather = null;
+        if (time > startTime) {
+            // Get the actual previous weather
+            const prevTime = time - calc.WEATHER_DURATION_MS;
+            previousWeather = calc.getWeatherForZone(zone, prevTime);
+        }
+
+        while (time < endTime && results.length < maxResults) {
+            const weather = calc.getWeatherForZone(zone, time);
+            const eorzeaTime = calc.getEorzeaTime(time);
+            const periodEnd = time + calc.WEATHER_DURATION_MS;
+
+            // Check if this weather matches the criteria
+            const match = this.matchesCriteria(weather, previousWeather, eorzeaTime, filters);
+
+            if (match) {
+                results.push({
+                    start: time,
+                    end: periodEnd,
+                    weather: weather,
+                    previousWeather: previousWeather,
+                    eorzeaTime: eorzeaTime,
+                    localStart: new Date(time),
+                    localEnd: new Date(periodEnd)
+                });
+            }
+
+            // Move to next period
+            previousWeather = weather;
+            time = periodEnd;
+        }
+
+        return results;
+    }
+
+    /**
+     * Check if a weather period matches the filter criteria
+     * @param {string} weather - Current weather name
+     * @param {string} previousWeather - Previous weather name
+     * @param {object} eorzeaTime - Eorzea time object
+     * @param {object} filters - Filter criteria
+     * @returns {boolean} True if matches all criteria
+     */
+    matchesCriteria(weather, previousWeather, eorzeaTime, filters) {
+        const calc = window.WeatherCalculator;
+
+        // Check desired weather
+        if (filters.desiredWeathers && filters.desiredWeathers.size > 0) {
+            if (!filters.desiredWeathers.has(weather)) {
+                return false;
+            }
+        }
+
+        // Check previous weather
+        if (filters.previousWeathers && filters.previousWeathers.size > 0) {
+            if (!previousWeather || !filters.previousWeathers.has(previousWeather)) {
+                return false;
+            }
+        }
+
+        // Check time range
+        if (filters.beginHour !== undefined && filters.endHour !== undefined) {
+            if (filters.beginHour !== 0 || filters.endHour !== 24) {
+                // Weather periods are 8 hours long, starting at 0, 8, or 16 ET
+                // Check if any part of the period falls within the time range
+                const periodStart = eorzeaTime.hours;
+                const periodEnd = (periodStart + 8) % 24;
+
+                // Check if the weather period overlaps with the desired time range
+                let overlaps = false;
+                for (let h = periodStart; h !== periodEnd; h = (h + 1) % 24) {
+                    if (calc.isInTimeRange(h, filters.beginHour, filters.endHour)) {
+                        overlaps = true;
+                        break;
+                    }
+                    // Safety check to prevent infinite loop
+                    if (h === periodStart && overlaps === false && ((periodStart + 1) % 24) === periodEnd) {
+                        break;
+                    }
+                }
+                // Also check the period end hour if it's inclusive
+                if (!overlaps && calc.isInTimeRange(periodEnd, filters.beginHour, filters.endHour)) {
+                    overlaps = true;
+                }
+
+                if (!overlaps) {
+                    return false;
+                }
+            }
+        }
+
+        // Check special events
+        if (filters.event) {
+            if (!this.matchesEvent(weather, previousWeather, filters.event)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if conditions match a special event
+     * @param {string} weather - Current weather
+     * @param {string} previousWeather - Previous weather
+     * @param {string} eventName - Event name
+     * @returns {boolean} True if matches event conditions
+     */
+    matchesEvent(weather, previousWeather, eventName) {
+        // Special event conditions
+        const events = {
+            'garlok': {
+                // Garlok spawns in Eastern La Noscea during Fog->Clear/Fair/Clouds
+                weathers: ['Clear Skies', 'Fair Skies', 'Clouds'],
+                previousWeathers: ['Fog']
+            },
+            'laideronnette': {
+                // Laideronnette appears in Central Shroud during Rain
+                weathers: ['Rain', 'Thunder']
+            }
+        };
+
+        const event = events[eventName.toLowerCase()];
+        if (!event) {
+            return true; // Unknown event, don't filter
+        }
+
+        if (event.weathers && !event.weathers.includes(weather)) {
+            return false;
+        }
+
+        if (event.previousWeathers && previousWeather && !event.previousWeathers.includes(previousWeather)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Find consecutive weather windows
+     * @param {object} zone - Zone object
+     * @param {Set} weathers - Set of weather names to chain
+     * @param {number} minDuration - Minimum duration in minutes
+     * @param {number} startTime - Search start timestamp
+     * @returns {array} Array of {start, end, duration, weathers} objects
+     */
+    findConsecutiveWeather(zone, weathers, minDuration, startTime = Date.now()) {
+        const calc = window.WeatherCalculator;
+        const results = [];
+        const searchDuration = this.defaultDays * 24 * 60 * 60 * 1000;
+        const endTime = startTime + searchDuration;
+        const minDurationMs = minDuration * 60 * 1000;
+
+        let time = calc.getWeatherPeriodStart(startTime);
+        let chainStart = null;
+        let chainWeathers = [];
+
+        while (time < endTime) {
+            const weather = calc.getWeatherForZone(zone, time);
+            const isMatching = weathers.has(weather);
+
+            if (isMatching) {
+                if (chainStart === null) {
+                    chainStart = time;
+                    chainWeathers = [weather];
+                } else {
+                    chainWeathers.push(weather);
+                }
+            } else {
+                // End of chain
+                if (chainStart !== null) {
+                    const chainEnd = time;
+                    const duration = chainEnd - chainStart;
+
+                    if (duration >= minDurationMs) {
+                        results.push({
+                            start: chainStart,
+                            end: chainEnd,
+                            duration: duration,
+                            durationMinutes: Math.round(duration / 60000),
+                            weathers: [...chainWeathers],
+                            localStart: new Date(chainStart),
+                            localEnd: new Date(chainEnd)
+                        });
+                    }
+
+                    chainStart = null;
+                    chainWeathers = [];
+                }
+            }
+
+            time += calc.WEATHER_DURATION_MS;
+        }
+
+        // Check final chain
+        if (chainStart !== null) {
+            const duration = time - chainStart;
+            if (duration >= minDurationMs) {
+                results.push({
+                    start: chainStart,
+                    end: time,
+                    duration: duration,
+                    durationMinutes: Math.round(duration / 60000),
+                    weathers: [...chainWeathers],
+                    localStart: new Date(chainStart),
+                    localEnd: new Date(time)
+                });
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Get upcoming weather changes (timetable view)
+     * @param {object} zone - Zone object
+     * @param {number} startTime - Start timestamp
+     * @param {number} count - Number of periods to return
+     * @returns {array} Array of weather period objects
+     */
+    getUpcomingWeather(zone, startTime = Date.now(), count = 24) {
+        const calc = window.WeatherCalculator;
+        const results = [];
+        let time = calc.getWeatherPeriodStart(startTime);
+        let previousWeather = null;
+
+        // Get previous weather if we're not at the start
+        if (time > 0) {
+            previousWeather = calc.getWeatherForZone(zone, time - calc.WEATHER_DURATION_MS);
+        }
+
+        for (let i = 0; i < count; i++) {
+            const weather = calc.getWeatherForZone(zone, time);
+            const eorzeaTime = calc.getEorzeaTime(time);
+            const periodEnd = time + calc.WEATHER_DURATION_MS;
+
+            results.push({
+                start: time,
+                end: periodEnd,
+                weather: weather,
+                previousWeather: previousWeather,
+                eorzeaTime: eorzeaTime,
+                localStart: new Date(time),
+                localEnd: new Date(periodEnd),
+                isCurrent: time <= Date.now() && periodEnd > Date.now()
+            });
+
+            previousWeather = weather;
+            time = periodEnd;
+        }
+
+        return results;
+    }
+
+    /**
+     * Group results by date for display
+     * @param {array} results - Array of weather period objects
+     * @returns {object} Object with date strings as keys
+     */
+    groupByDate(results) {
+        const grouped = {};
+
+        for (const result of results) {
+            const date = result.localStart.toLocaleDateString();
+            if (!grouped[date]) {
+                grouped[date] = [];
+            }
+            grouped[date].push(result);
+        }
+
+        return grouped;
+    }
+
+    /**
+     * Get statistics about weather in a zone
+     * @param {object} zone - Zone object
+     * @param {number} periods - Number of periods to analyze
+     * @returns {object} Statistics object
+     */
+    getWeatherStats(zone, periods = 1000) {
+        const calc = window.WeatherCalculator;
+        const counts = {};
+        let time = calc.getWeatherPeriodStart(Date.now());
+
+        for (let i = 0; i < periods; i++) {
+            const weather = calc.getWeatherForZone(zone, time);
+            counts[weather] = (counts[weather] || 0) + 1;
+            time += calc.WEATHER_DURATION_MS;
+        }
+
+        // Convert to percentages
+        const stats = {};
+        for (const [weather, count] of Object.entries(counts)) {
+            stats[weather] = {
+                count: count,
+                percentage: Math.round((count / periods) * 100 * 10) / 10
+            };
+        }
+
+        return stats;
+    }
+}
+
+// Export for use in other modules
+window.WeatherSearch = WeatherSearch;

--- a/tools/weather-forecast/weather-search.js
+++ b/tools/weather-forecast/weather-search.js
@@ -40,12 +40,7 @@ class WeatherSearch {
         let time = calc.getWeatherPeriodStart(startTime);
 
         // Track previous weather for transition checks
-        let previousWeather = null;
-        if (time > startTime) {
-            // Get the actual previous weather
-            const prevTime = time - calc.WEATHER_DURATION_MS;
-            previousWeather = calc.getWeatherForZone(zone, prevTime);
-        }
+        let previousWeather = calc.getWeatherForZone(zone, time - calc.WEATHER_DURATION_MS);
 
         while (time < endTime && results.length < maxResults) {
             const weather = calc.getWeatherForZone(zone, time);

--- a/tools/weather-forecast/weather-search.js
+++ b/tools/weather-forecast/weather-search.js
@@ -103,29 +103,9 @@ class WeatherSearch {
         // Check time range
         if (filters.beginHour !== undefined && filters.endHour !== undefined) {
             if (filters.beginHour !== 0 || filters.endHour !== 24) {
-                // Weather periods are 8 hours long, starting at 0, 8, or 16 ET
-                // Check if any part of the period falls within the time range
-                const periodStart = eorzeaTime.hours;
-                const periodEnd = (periodStart + 8) % 24;
-
                 // Check if the weather period overlaps with the desired time range
-                let overlaps = false;
-                for (let h = periodStart; h !== periodEnd; h = (h + 1) % 24) {
-                    if (calc.isInTimeRange(h, filters.beginHour, filters.endHour)) {
-                        overlaps = true;
-                        break;
-                    }
-                    // Safety check to prevent infinite loop
-                    if (h === periodStart && overlaps === false && ((periodStart + 1) % 24) === periodEnd) {
-                        break;
-                    }
-                }
-                // Also check the period end hour if it's inclusive
-                if (!overlaps && calc.isInTimeRange(periodEnd, filters.beginHour, filters.endHour)) {
-                    overlaps = true;
-                }
-
-                if (!overlaps) {
+                const overlappingPeriods = calc.getOverlappingWeatherPeriods(filters.beginHour, filters.endHour);
+                if (!overlappingPeriods.includes(eorzeaTime.hours)) {
                     return false;
                 }
             }

--- a/tools/weather-forecast/weather-store.js
+++ b/tools/weather-forecast/weather-store.js
@@ -389,10 +389,6 @@ class WeatherStore {
         for (let i = 0; i < table.length; i += 2) {
             weathers.add(table[i]);
         }
-        // Last weather if odd length
-        if (table.length % 2 === 1) {
-            weathers.add(table[table.length - 1]);
-        }
 
         return Array.from(weathers);
     }

--- a/tools/weather-forecast/weather-store.js
+++ b/tools/weather-forecast/weather-store.js
@@ -1,0 +1,402 @@
+/**
+ * FF14 Weather Forecast - Weather Store
+ * Reactive state management with URL hash synchronization
+ */
+
+class WeatherStore {
+    /**
+     * Create a new WeatherStore instance
+     */
+    constructor() {
+        // State
+        this.state = {
+            zoneId: null,
+            desiredWeathers: new Set(),
+            previousWeathers: new Set(),
+            beginHour: 0,
+            endHour: 24,
+            event: null
+        };
+
+        // Subscribers
+        this.subscribers = [];
+
+        // Bind methods
+        this.handleHashChange = this.handleHashChange.bind(this);
+    }
+
+    /**
+     * Initialize the store and set up hash change listener
+     */
+    init() {
+        // Listen for hash changes
+        window.addEventListener('hashchange', this.handleHashChange);
+
+        // Load initial state from hash
+        this.loadFromHash();
+    }
+
+    /**
+     * Destroy the store and remove listeners
+     */
+    destroy() {
+        window.removeEventListener('hashchange', this.handleHashChange);
+        this.subscribers = [];
+    }
+
+    /**
+     * Subscribe to state changes
+     * @param {function} callback - Function to call when state changes
+     * @returns {function} Unsubscribe function
+     */
+    subscribe(callback) {
+        this.subscribers.push(callback);
+        return () => {
+            this.subscribers = this.subscribers.filter(cb => cb !== callback);
+        };
+    }
+
+    /**
+     * Notify all subscribers of state change
+     * @param {string} changeType - Type of change that occurred
+     */
+    notify(changeType) {
+        for (const callback of this.subscribers) {
+            callback(this.state, changeType);
+        }
+    }
+
+    /**
+     * Handle hash change event
+     */
+    handleHashChange() {
+        this.loadFromHash();
+    }
+
+    /**
+     * Load state from URL hash
+     * Format: #zone-id-w1-w2-p1-p2-b-e-event
+     * Where w = desired weather indices, p = previous weather indices,
+     * b = begin hour, e = end hour
+     */
+    loadFromHash() {
+        const hash = window.location.hash.slice(1);
+        if (!hash) {
+            this.reset();
+            return;
+        }
+
+        const parts = hash.split('-');
+        if (parts.length === 0) {
+            this.reset();
+            return;
+        }
+
+        // Parse zone ID (may contain dashes)
+        // Try to find a matching zone by progressively combining parts
+        let zoneId = null;
+        let remainingIndex = 0;
+
+        for (let i = 1; i <= parts.length; i++) {
+            const testId = parts.slice(0, i).join('-');
+            if (window.WeatherZoneData && window.WeatherZoneData.getZone(testId)) {
+                zoneId = testId;
+                remainingIndex = i;
+            }
+        }
+
+        if (!zoneId) {
+            this.reset();
+            return;
+        }
+
+        // Parse remaining parameters
+        const params = parts.slice(remainingIndex);
+        const desiredWeathers = new Set();
+        const previousWeathers = new Set();
+        let beginHour = 0;
+        let endHour = 24;
+        let event = null;
+
+        // Simple format: just zone
+        if (params.length === 0) {
+            this.setState({
+                zoneId,
+                desiredWeathers,
+                previousWeathers,
+                beginHour,
+                endHour,
+                event
+            });
+            return;
+        }
+
+        // Extended format: zone-dw-pw-begin-end-event
+        // dw = desired weathers (comma-separated indices)
+        // pw = previous weathers (comma-separated indices)
+        // begin = begin hour
+        // end = end hour
+        // event = special event name
+
+        if (params.length >= 1 && params[0]) {
+            const indices = params[0].split(',').filter(Boolean);
+            for (const idx of indices) {
+                const weatherName = this.getWeatherByIndex(parseInt(idx, 10));
+                if (weatherName) {
+                    desiredWeathers.add(weatherName);
+                }
+            }
+        }
+
+        if (params.length >= 2 && params[1]) {
+            const indices = params[1].split(',').filter(Boolean);
+            for (const idx of indices) {
+                const weatherName = this.getWeatherByIndex(parseInt(idx, 10));
+                if (weatherName) {
+                    previousWeathers.add(weatherName);
+                }
+            }
+        }
+
+        if (params.length >= 3 && params[2]) {
+            beginHour = parseInt(params[2], 10) || 0;
+        }
+
+        if (params.length >= 4 && params[3]) {
+            endHour = parseInt(params[3], 10) || 24;
+        }
+
+        if (params.length >= 5 && params[4]) {
+            event = params[4] || null;
+        }
+
+        this.setState({
+            zoneId,
+            desiredWeathers,
+            previousWeathers,
+            beginHour,
+            endHour,
+            event
+        });
+    }
+
+    /**
+     * Save current state to URL hash
+     */
+    saveToHash() {
+        if (!this.state.zoneId) {
+            history.replaceState(null, '', window.location.pathname);
+            return;
+        }
+
+        let hash = this.state.zoneId;
+
+        // Only add parameters if there are filters
+        const hasFilters =
+            this.state.desiredWeathers.size > 0 ||
+            this.state.previousWeathers.size > 0 ||
+            this.state.beginHour !== 0 ||
+            this.state.endHour !== 24 ||
+            this.state.event;
+
+        if (hasFilters) {
+            // Desired weathers
+            const dwIndices = Array.from(this.state.desiredWeathers)
+                .map(w => this.getWeatherIndex(w))
+                .filter(i => i !== -1)
+                .join(',');
+
+            // Previous weathers
+            const pwIndices = Array.from(this.state.previousWeathers)
+                .map(w => this.getWeatherIndex(w))
+                .filter(i => i !== -1)
+                .join(',');
+
+            hash += `-${dwIndices}-${pwIndices}-${this.state.beginHour}-${this.state.endHour}`;
+
+            if (this.state.event) {
+                hash += `-${this.state.event}`;
+            }
+        }
+
+        history.replaceState(null, '', `#${hash}`);
+    }
+
+    /**
+     * Get weather index for hash encoding
+     * @param {string} weatherName - Weather name
+     * @returns {number} Weather index or -1 if not found
+     */
+    getWeatherIndex(weatherName) {
+        if (!window.WeatherZoneData) return -1;
+        const weatherTypes = Object.keys(window.WeatherZoneData.weatherTypes);
+        return weatherTypes.indexOf(weatherName);
+    }
+
+    /**
+     * Get weather name from index
+     * @param {number} index - Weather index
+     * @returns {string|null} Weather name or null if invalid
+     */
+    getWeatherByIndex(index) {
+        if (!window.WeatherZoneData) return null;
+        const weatherTypes = Object.keys(window.WeatherZoneData.weatherTypes);
+        return weatherTypes[index] || null;
+    }
+
+    /**
+     * Set the entire state
+     * @param {object} newState - New state object
+     * @param {boolean} updateHash - Whether to update URL hash
+     */
+    setState(newState, updateHash = false) {
+        this.state = { ...newState };
+        if (updateHash) {
+            this.saveToHash();
+        }
+        this.notify('state');
+    }
+
+    /**
+     * Reset state to defaults
+     */
+    reset() {
+        this.state = {
+            zoneId: null,
+            desiredWeathers: new Set(),
+            previousWeathers: new Set(),
+            beginHour: 0,
+            endHour: 24,
+            event: null
+        };
+        this.notify('reset');
+    }
+
+    /**
+     * Set the selected zone
+     * @param {string} zoneId - Zone ID
+     */
+    setZone(zoneId) {
+        this.state.zoneId = zoneId;
+        this.state.desiredWeathers = new Set();
+        this.state.previousWeathers = new Set();
+        this.state.beginHour = 0;
+        this.state.endHour = 24;
+        this.state.event = null;
+        this.saveToHash();
+        this.notify('zone');
+    }
+
+    /**
+     * Toggle a desired weather
+     * @param {string} weatherName - Weather name to toggle
+     */
+    toggleDesiredWeather(weatherName) {
+        if (this.state.desiredWeathers.has(weatherName)) {
+            this.state.desiredWeathers.delete(weatherName);
+        } else {
+            this.state.desiredWeathers.add(weatherName);
+        }
+        this.saveToHash();
+        this.notify('desiredWeathers');
+    }
+
+    /**
+     * Toggle a previous weather
+     * @param {string} weatherName - Weather name to toggle
+     */
+    togglePreviousWeather(weatherName) {
+        if (this.state.previousWeathers.has(weatherName)) {
+            this.state.previousWeathers.delete(weatherName);
+        } else {
+            this.state.previousWeathers.add(weatherName);
+        }
+        this.saveToHash();
+        this.notify('previousWeathers');
+    }
+
+    /**
+     * Set the time range
+     * @param {number} beginHour - Begin hour (0-23)
+     * @param {number} endHour - End hour (0-24)
+     */
+    setTimeRange(beginHour, endHour) {
+        this.state.beginHour = beginHour;
+        this.state.endHour = endHour;
+        this.saveToHash();
+        this.notify('timeRange');
+    }
+
+    /**
+     * Set a special event filter
+     * @param {string|null} event - Event name or null to clear
+     */
+    setEvent(event) {
+        this.state.event = event;
+        this.saveToHash();
+        this.notify('event');
+    }
+
+    /**
+     * Clear all filters but keep zone
+     */
+    clearFilters() {
+        this.state.desiredWeathers = new Set();
+        this.state.previousWeathers = new Set();
+        this.state.beginHour = 0;
+        this.state.endHour = 24;
+        this.state.event = null;
+        this.saveToHash();
+        this.notify('clearFilters');
+    }
+
+    /**
+     * Check if there are any active filters
+     * @returns {boolean} True if any filters are active
+     */
+    hasActiveFilters() {
+        return (
+            this.state.desiredWeathers.size > 0 ||
+            this.state.previousWeathers.size > 0 ||
+            this.state.beginHour !== 0 ||
+            this.state.endHour !== 24 ||
+            this.state.event !== null
+        );
+    }
+
+    /**
+     * Get the current zone object
+     * @returns {object|null} Zone object or null
+     */
+    getCurrentZone() {
+        if (!this.state.zoneId || !window.WeatherZoneData) {
+            return null;
+        }
+        return window.WeatherZoneData.getZone(this.state.zoneId);
+    }
+
+    /**
+     * Get available weathers for the current zone
+     * @returns {array} Array of weather names
+     */
+    getAvailableWeathers() {
+        const zone = this.getCurrentZone();
+        if (!zone) return [];
+
+        const weathers = new Set();
+        const table = zone.weatherTable;
+
+        for (let i = 0; i < table.length; i += 2) {
+            weathers.add(table[i]);
+        }
+        // Last weather if odd length
+        if (table.length % 2 === 1) {
+            weathers.add(table[table.length - 1]);
+        }
+
+        return Array.from(weathers);
+    }
+}
+
+// Export for use in other modules
+window.WeatherStore = WeatherStore;

--- a/tools/weather-forecast/weather-store.js
+++ b/tools/weather-forecast/weather-store.js
@@ -159,15 +159,20 @@ class WeatherStore {
         }
 
         if (params.length >= 3 && params[2]) {
-            beginHour = parseInt(params[2], 10) || 0;
+            const parsed = parseInt(params[2], 10);
+            beginHour = isNaN(parsed) ? 0 : Math.max(0, Math.min(23, parsed));
         }
 
         if (params.length >= 4 && params[3]) {
-            endHour = parseInt(params[3], 10) || 24;
+            const parsed = parseInt(params[3], 10);
+            endHour = isNaN(parsed) ? 24 : Math.max(0, Math.min(24, parsed));
         }
 
         if (params.length >= 5 && params[4]) {
-            event = params[4] || null;
+            // Validate event name against known events
+            const validEvents = ['garlok', 'laideronnette'];
+            const eventValue = params[4].toLowerCase();
+            event = validEvents.includes(eventValue) ? eventValue : null;
         }
 
         this.setState({

--- a/tools/weather-forecast/zone-data.js
+++ b/tools/weather-forecast/zone-data.js
@@ -150,7 +150,7 @@ const WeatherZoneData = {
 
         // Special / Miscellaneous
         { id: 'wolves-den-pier', region: 'la-noscea', zh: '狼獄演習場', en: "Wolves' Den Pier", ja: 'ウルヴズジェイル演習場', weatherTable: ['Clear Skies', 20, 'Fair Skies', 50, 'Clouds', 70, 'Fog', 80, 'Wind', 90, 'Rain'] },
-        { id: 'eureka-anemos', region: 'othard', zh: '恆冰之地', en: 'Eureka Anemos', ja: '禁断の地 エウレカ：アネモス帯', weatherTable: ['Fair Skies', 30, 'Gales', 60, 'Showers', 90, 'Snow'] },
+        { id: 'eureka-anemos', region: 'othard', zh: '常風之地', en: 'Eureka Anemos', ja: '禁断の地 エウレカ：アネモス帯', weatherTable: ['Fair Skies', 30, 'Gales', 60, 'Showers', 90, 'Snow'] },
         { id: 'eureka-pagos', region: 'othard', zh: '恆冰之地', en: 'Eureka Pagos', ja: '禁断の地 エウレカ：パゴス帯', weatherTable: ['Clear Skies', 10, 'Fog', 28, 'Heat Waves', 46, 'Snow', 64, 'Thunder', 82, 'Blizzards'] },
         { id: 'eureka-pyros', region: 'othard', zh: '涌火之地', en: 'Eureka Pyros', ja: '禁断の地 エウレカ：ピューロス帯', weatherTable: ['Fair Skies', 10, 'Heat Waves', 28, 'Thunder', 46, 'Blizzards', 64, 'Umbral Wind', 82, 'Snow'] },
         { id: 'eureka-hydatos', region: 'othard', zh: '湧水之地', en: 'Eureka Hydatos', ja: '禁断の地 エウレカ：ヒュダトス帯', weatherTable: ['Fair Skies', 12, 'Showers', 34, 'Gloom', 56, 'Thunderstorms', 78, 'Snow'] },

--- a/tools/weather-forecast/zone-data.js
+++ b/tools/weather-forecast/zone-data.js
@@ -66,7 +66,7 @@ const WeatherZoneData = {
         { id: 'mist', region: 'la-noscea', zh: '海霧村', en: 'Mist', ja: 'ミスト・ヴィレッジ', weatherTable: ['Clouds', 20, 'Clear Skies', 50, 'Fair Skies', 70, 'Fog', 80, 'Rain'] },
 
         // The Black Shroud
-        { id: 'gridania', region: 'black-shroud', zh: '格里達尼亞', en: 'Gridania', ja: 'グリダニア', weatherTable: ['Rain', 5, 'Rain', 20, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 55, 'Clear Skies', 85, 'Fair Skies'] },
+        { id: 'gridania', region: 'black-shroud', zh: '格里達尼亞', en: 'Gridania', ja: 'グリダニア', weatherTable: ['Rain', 20, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 55, 'Clear Skies', 85, 'Fair Skies'] },
         { id: 'central-shroud', region: 'black-shroud', zh: '黑衣森林中央林區', en: 'Central Shroud', ja: '黒衣森：中央森林', weatherTable: ['Thunder', 5, 'Rain', 20, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 55, 'Clear Skies', 85, 'Fair Skies'] },
         { id: 'east-shroud', region: 'black-shroud', zh: '黑衣森林東部林區', en: 'East Shroud', ja: '黒衣森：東部森林', weatherTable: ['Thunder', 5, 'Rain', 20, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 55, 'Clear Skies', 85, 'Fair Skies'] },
         { id: 'south-shroud', region: 'black-shroud', zh: '黑衣森林南部林區', en: 'South Shroud', ja: '黒衣森：南部森林', weatherTable: ['Fog', 5, 'Thunderstorms', 10, 'Thunder', 25, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 70, 'Clear Skies'] },
@@ -211,10 +211,6 @@ const WeatherZoneData = {
             const table = zone.weatherTable;
             for (let i = 0; i < table.length; i += 2) {
                 weatherSet.add(table[i]);
-            }
-            // Last weather (no chance value after it)
-            if (table.length % 2 === 1) {
-                weatherSet.add(table[table.length - 1]);
             }
         }
         return Array.from(weatherSet).sort();

--- a/tools/weather-forecast/zone-data.js
+++ b/tools/weather-forecast/zone-data.js
@@ -1,0 +1,225 @@
+/**
+ * FF14 Weather Forecast - Zone Data
+ * Contains all 78 zones with weather tables for weather calculation
+ */
+
+const WeatherZoneData = {
+    // Weather types with icons
+    weatherTypes: {
+        'Clear Skies': { icon: '☀️', zh: '晴朗', en: 'Clear Skies', ja: '快晴' },
+        'Fair Skies': { icon: '🌤️', zh: '碧空', en: 'Fair Skies', ja: '晴れ' },
+        'Clouds': { icon: '☁️', zh: '陰天', en: 'Clouds', ja: '曇り' },
+        'Fog': { icon: '🌫️', zh: '濃霧', en: 'Fog', ja: '霧' },
+        'Wind': { icon: '💨', zh: '微風', en: 'Wind', ja: '風' },
+        'Gales': { icon: '🌬️', zh: '強風', en: 'Gales', ja: '暴風' },
+        'Rain': { icon: '🌧️', zh: '小雨', en: 'Rain', ja: '雨' },
+        'Showers': { icon: '🌦️', zh: '陣雨', en: 'Showers', ja: 'にわか雨' },
+        'Thunder': { icon: '⛈️', zh: '雷雨', en: 'Thunder', ja: '雷' },
+        'Thunderstorms': { icon: '🌩️', zh: '暴風雨', en: 'Thunderstorms', ja: '雷雨' },
+        'Dust Storms': { icon: '🏜️', zh: '沙塵暴', en: 'Dust Storms', ja: '砂塵' },
+        'Heat Waves': { icon: '🔥', zh: '熱浪', en: 'Heat Waves', ja: '灼熱波' },
+        'Snow': { icon: '❄️', zh: '飄雪', en: 'Snow', ja: '雪' },
+        'Blizzards': { icon: '🌨️', zh: '暴風雪', en: 'Blizzards', ja: '吹雪' },
+        'Gloom': { icon: '🌑', zh: '薄暗', en: 'Gloom', ja: '妖霧' },
+        'Umbral Wind': { icon: '🌀', zh: '靈風', en: 'Umbral Wind', ja: '霊風' },
+        'Umbral Static': { icon: '⚡', zh: '靈電', en: 'Umbral Static', ja: '放電' },
+        'Eruptions': { icon: '🌋', zh: '火山灰', en: 'Eruptions', ja: '噴煙' },
+        'Moon Dust': { icon: '🌙', zh: '月塵', en: 'Moon Dust', ja: '月砂塵' },
+        'Astromagnetic Storm': { icon: '💫', zh: '星磁暴', en: 'Astromagnetic Storm', ja: '星磁嵐' },
+        'Hyperelectricity': { icon: '⚡', zh: '超電磁', en: 'Hyperelectricity', ja: '超電磁嵐' },
+        'Royal Levin': { icon: '👑', zh: '皇雷', en: 'Royal Levin', ja: '皇雷' },
+        'Shelf Clouds': { icon: '🌪️', zh: '弧狀雲', en: 'Shelf Clouds', ja: '弧状雲' },
+        'Oppression': { icon: '😰', zh: '悶熱', en: 'Oppression', ja: '蒸熱' },
+        'Sunshine': { icon: '🌞', zh: '烈日', en: 'Sunshine', ja: '陽光' }
+    },
+
+    // Regions
+    regions: {
+        'la-noscea': { zh: '拉諾西亞', en: 'La Noscea', ja: 'ラノシア' },
+        'black-shroud': { zh: '黑衣森林', en: 'The Black Shroud', ja: '黒衣森' },
+        'thanalan': { zh: '薩納蘭', en: 'Thanalan', ja: 'ザナラーン' },
+        'coerthas': { zh: '庫爾札斯', en: 'Coerthas', ja: 'クルザス' },
+        'mor-dhona': { zh: '摩杜納', en: 'Mor Dhona', ja: 'モードゥナ' },
+        'abalathia': { zh: '阿巴拉提亞', en: "Abalathia's Spine", ja: 'アバラシア' },
+        'dravania': { zh: '龍堡', en: 'Dravania', ja: 'ドラヴァニア' },
+        'gyr-abania': { zh: '基拉巴尼亞', en: 'Gyr Abania', ja: 'ギラバニア' },
+        'othard': { zh: '奧薩德', en: 'Othard', ja: 'オサード' },
+        'norvrandt': { zh: '諾弗蘭特', en: 'Norvrandt', ja: 'ノルヴラント' },
+        'ilsabard': { zh: '伊爾薩巴德', en: 'Ilsabard', ja: 'イルサバード' },
+        'the-sea-of-stars': { zh: '星海', en: 'The Sea of Stars', ja: '星海' },
+        'the-world-unsundered': { zh: '未分離的世界', en: 'The World Unsundered', ja: '未分裂の世界' },
+        'tural': { zh: '圖拉爾', en: 'Tural', ja: 'トラル' }
+    },
+
+    // All 78 zones with weather tables
+    // Weather table format: [weather1, chance1, weather2, chance2, ..., weatherN]
+    // Chances are cumulative (0-99), last weather has no chance (covers remaining)
+    zones: [
+        // La Noscea
+        { id: 'limsa-lominsa', region: 'la-noscea', zh: '利姆薩·羅敏薩', en: 'Limsa Lominsa', ja: 'リムサ・ロミンサ', weatherTable: ['Clouds', 20, 'Clear Skies', 50, 'Fair Skies', 80, 'Fog', 90, 'Rain'] },
+        { id: 'middle-la-noscea', region: 'la-noscea', zh: '中拉諾西亞', en: 'Middle La Noscea', ja: '中央ラノシア', weatherTable: ['Clouds', 20, 'Clear Skies', 50, 'Fair Skies', 70, 'Wind', 80, 'Fog', 90, 'Rain'] },
+        { id: 'lower-la-noscea', region: 'la-noscea', zh: '拉諾西亞低地', en: 'Lower La Noscea', ja: '低地ラノシア', weatherTable: ['Clouds', 20, 'Clear Skies', 50, 'Fair Skies', 70, 'Wind', 80, 'Fog', 90, 'Rain'] },
+        { id: 'eastern-la-noscea', region: 'la-noscea', zh: '東拉諾西亞', en: 'Eastern La Noscea', ja: '東ラノシア', weatherTable: ['Fog', 5, 'Clear Skies', 50, 'Fair Skies', 80, 'Clouds', 90, 'Rain', 95, 'Showers'] },
+        { id: 'western-la-noscea', region: 'la-noscea', zh: '西拉諾西亞', en: 'Western La Noscea', ja: '西ラノシア', weatherTable: ['Fog', 10, 'Clear Skies', 40, 'Fair Skies', 60, 'Clouds', 80, 'Wind', 90, 'Gales'] },
+        { id: 'upper-la-noscea', region: 'la-noscea', zh: '拉諾西亞高地', en: 'Upper La Noscea', ja: '高地ラノシア', weatherTable: ['Clear Skies', 30, 'Fair Skies', 50, 'Clouds', 70, 'Fog', 80, 'Thunder', 90, 'Thunderstorms'] },
+        { id: 'outer-la-noscea', region: 'la-noscea', zh: '拉諾西亞外地', en: 'Outer La Noscea', ja: '外地ラノシア', weatherTable: ['Clear Skies', 30, 'Fair Skies', 50, 'Clouds', 70, 'Fog', 85, 'Rain'] },
+        { id: 'mist', region: 'la-noscea', zh: '海霧村', en: 'Mist', ja: 'ミスト・ヴィレッジ', weatherTable: ['Clouds', 20, 'Clear Skies', 50, 'Fair Skies', 70, 'Fog', 80, 'Rain'] },
+
+        // The Black Shroud
+        { id: 'gridania', region: 'black-shroud', zh: '格里達尼亞', en: 'Gridania', ja: 'グリダニア', weatherTable: ['Rain', 5, 'Rain', 20, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 55, 'Clear Skies', 85, 'Fair Skies'] },
+        { id: 'central-shroud', region: 'black-shroud', zh: '黑衣森林中央林區', en: 'Central Shroud', ja: '黒衣森：中央森林', weatherTable: ['Thunder', 5, 'Rain', 20, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 55, 'Clear Skies', 85, 'Fair Skies'] },
+        { id: 'east-shroud', region: 'black-shroud', zh: '黑衣森林東部林區', en: 'East Shroud', ja: '黒衣森：東部森林', weatherTable: ['Thunder', 5, 'Rain', 20, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 55, 'Clear Skies', 85, 'Fair Skies'] },
+        { id: 'south-shroud', region: 'black-shroud', zh: '黑衣森林南部林區', en: 'South Shroud', ja: '黒衣森：南部森林', weatherTable: ['Fog', 5, 'Thunderstorms', 10, 'Thunder', 25, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 70, 'Clear Skies'] },
+        { id: 'north-shroud', region: 'black-shroud', zh: '黑衣森林北部林區', en: 'North Shroud', ja: '黒衣森：北部森林', weatherTable: ['Fog', 5, 'Showers', 10, 'Rain', 25, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 70, 'Clear Skies'] },
+        { id: 'lavender-beds', region: 'black-shroud', zh: '薰衣草苗圃', en: 'The Lavender Beds', ja: 'ラベンダーベッド', weatherTable: ['Clouds', 5, 'Rain', 20, 'Fog', 30, 'Clouds', 40, 'Fair Skies', 55, 'Clear Skies', 85, 'Fair Skies'] },
+
+        // Thanalan
+        { id: 'uldah', region: 'thanalan', zh: '烏爾達哈', en: "Ul'dah", ja: 'ウルダハ', weatherTable: ['Clear Skies', 40, 'Fair Skies', 60, 'Clouds', 85, 'Fog', 95, 'Rain'] },
+        { id: 'western-thanalan', region: 'thanalan', zh: '西薩納蘭', en: 'Western Thanalan', ja: '西ザナラーン', weatherTable: ['Clear Skies', 40, 'Fair Skies', 60, 'Clouds', 85, 'Fog', 95, 'Rain'] },
+        { id: 'central-thanalan', region: 'thanalan', zh: '中薩納蘭', en: 'Central Thanalan', ja: '中央ザナラーン', weatherTable: ['Dust Storms', 15, 'Clear Skies', 55, 'Fair Skies', 75, 'Clouds', 85, 'Fog', 95, 'Rain'] },
+        { id: 'eastern-thanalan', region: 'thanalan', zh: '東薩納蘭', en: 'Eastern Thanalan', ja: '東ザナラーン', weatherTable: ['Clear Skies', 40, 'Fair Skies', 60, 'Clouds', 70, 'Fog', 80, 'Rain', 85, 'Showers'] },
+        { id: 'southern-thanalan', region: 'thanalan', zh: '南薩納蘭', en: 'Southern Thanalan', ja: '南ザナラーン', weatherTable: ['Heat Waves', 20, 'Clear Skies', 60, 'Fair Skies', 80, 'Clouds', 90, 'Fog'] },
+        { id: 'northern-thanalan', region: 'thanalan', zh: '北薩納蘭', en: 'Northern Thanalan', ja: '北ザナラーン', weatherTable: ['Clear Skies', 5, 'Fair Skies', 20, 'Clouds', 50, 'Fog'] },
+        { id: 'goblet', region: 'thanalan', zh: '高腳孤丘', en: 'The Goblet', ja: 'ゴブレットビュート', weatherTable: ['Clear Skies', 40, 'Fair Skies', 60, 'Clouds', 85, 'Fog', 95, 'Rain'] },
+
+        // Coerthas
+        { id: 'ishgard', region: 'coerthas', zh: '伊修加德', en: 'Ishgard', ja: 'イシュガルド', weatherTable: ['Snow', 60, 'Fair Skies', 70, 'Clear Skies', 75, 'Clouds', 90, 'Fog'] },
+        { id: 'coerthas-central', region: 'coerthas', zh: '庫爾札斯中央高地', en: 'Coerthas Central Highlands', ja: 'クルザス中央高地', weatherTable: ['Blizzards', 20, 'Snow', 60, 'Fair Skies', 70, 'Clear Skies', 75, 'Clouds', 90, 'Fog'] },
+        { id: 'coerthas-western', region: 'coerthas', zh: '庫爾札斯西部高地', en: 'Coerthas Western Highlands', ja: 'クルザス西部高地', weatherTable: ['Blizzards', 20, 'Snow', 60, 'Fair Skies', 70, 'Clear Skies', 75, 'Clouds', 90, 'Fog'] },
+        { id: 'empyreum', region: 'coerthas', zh: '穹頂皓天', en: 'Empyreum', ja: 'エンピレアム', weatherTable: ['Snow', 15, 'Fair Skies', 45, 'Clear Skies', 60, 'Clouds', 80, 'Fog'] },
+
+        // Mor Dhona
+        { id: 'mor-dhona', region: 'mor-dhona', zh: '摩杜納', en: 'Mor Dhona', ja: 'モードゥナ', weatherTable: ['Clouds', 15, 'Fog', 30, 'Gloom', 60, 'Clear Skies', 75, 'Fair Skies'] },
+
+        // Abalathia's Spine
+        { id: 'sea-of-clouds', region: 'abalathia', zh: '阿巴拉提亞雲海', en: 'The Sea of Clouds', ja: 'アバラシア雲海', weatherTable: ['Clear Skies', 30, 'Fair Skies', 60, 'Clouds', 70, 'Fog', 80, 'Wind', 90, 'Umbral Wind'] },
+        { id: 'azys-lla', region: 'abalathia', zh: '魔大陸阿濟茲拉', en: 'Azys Lla', ja: 'アジス・ラー', weatherTable: ['Fair Skies', 35, 'Clouds', 70, 'Thunder'] },
+
+        // Dravania
+        { id: 'idyllshire', region: 'dravania', zh: '田園郡', en: 'Idyllshire', ja: 'イディルシャイア', weatherTable: ['Clouds', 10, 'Fog', 20, 'Rain', 30, 'Showers', 40, 'Clear Skies', 70, 'Fair Skies'] },
+        { id: 'churning-mists', region: 'dravania', zh: '龍堡參天高地', en: 'The Churning Mists', ja: 'ドラヴァニア雲海', weatherTable: ['Clouds', 10, 'Gales', 20, 'Umbral Static', 40, 'Clear Skies', 70, 'Fair Skies'] },
+        { id: 'dravanian-forelands', region: 'dravania', zh: '龍堡內陸低地', en: 'The Dravanian Forelands', ja: 'ドラヴァニア前線', weatherTable: ['Clouds', 10, 'Fog', 20, 'Thunder', 30, 'Dust Storms', 40, 'Clear Skies', 70, 'Fair Skies'] },
+        { id: 'dravanian-hinterlands', region: 'dravania', zh: '龍堡內陸', en: 'The Dravanian Hinterlands', ja: 'ドラヴァニア内地', weatherTable: ['Clouds', 10, 'Fog', 20, 'Rain', 30, 'Showers', 40, 'Clear Skies', 70, 'Fair Skies'] },
+
+        // Gyr Abania
+        { id: 'rhalgrs-reach', region: 'gyr-abania', zh: '神拳痕', en: "Rhalgr's Reach", ja: 'ラールガーズリーチ', weatherTable: ['Clear Skies', 15, 'Fair Skies', 60, 'Clouds', 80, 'Fog', 90, 'Thunder'] },
+        { id: 'fringes', region: 'gyr-abania', zh: '基拉巴尼亞邊區', en: 'The Fringes', ja: 'ギラバニア辺境地帯', weatherTable: ['Clear Skies', 15, 'Fair Skies', 60, 'Clouds', 80, 'Fog', 90, 'Thunder'] },
+        { id: 'peaks', region: 'gyr-abania', zh: '基拉巴尼亞山區', en: 'The Peaks', ja: 'ギラバニア山岳地帯', weatherTable: ['Clear Skies', 10, 'Fair Skies', 60, 'Clouds', 75, 'Fog', 85, 'Wind', 95, 'Dust Storms'] },
+        { id: 'lochs', region: 'gyr-abania', zh: '基拉巴尼亞湖區', en: 'The Lochs', ja: 'ギラバニア湖畔地帯', weatherTable: ['Clear Skies', 20, 'Fair Skies', 60, 'Clouds', 80, 'Fog', 90, 'Thunderstorms'] },
+
+        // Othard
+        { id: 'kugane', region: 'othard', zh: '神拳流國際港都', en: 'Kugane', ja: 'クガネ', weatherTable: ['Rain', 10, 'Fog', 20, 'Clouds', 40, 'Fair Skies', 80, 'Clear Skies'] },
+        { id: 'ruby-sea', region: 'othard', zh: '紅玉海', en: 'The Ruby Sea', ja: '紅玉海', weatherTable: ['Thunder', 10, 'Wind', 20, 'Clouds', 35, 'Fair Skies', 75, 'Clear Skies'] },
+        { id: 'yanxia', region: 'othard', zh: '延夏', en: 'Yanxia', ja: 'ヤンサ', weatherTable: ['Showers', 5, 'Rain', 15, 'Fog', 25, 'Clouds', 40, 'Fair Skies', 80, 'Clear Skies'] },
+        { id: 'azim-steppe', region: 'othard', zh: '太陽神草原', en: 'The Azim Steppe', ja: 'アジムステップ', weatherTable: ['Gales', 5, 'Wind', 10, 'Rain', 17, 'Fog', 25, 'Clouds', 35, 'Fair Skies', 75, 'Clear Skies'] },
+        { id: 'shirogane', region: 'othard', zh: '白銀鄉', en: 'Shirogane', ja: 'シロガネ', weatherTable: ['Rain', 10, 'Fog', 20, 'Clouds', 40, 'Fair Skies', 80, 'Clear Skies'] },
+
+        // Norvrandt
+        { id: 'crystarium', region: 'norvrandt', zh: '水晶都', en: 'The Crystarium', ja: 'クリスタリウム', weatherTable: ['Clear Skies', 20, 'Fair Skies', 60, 'Clouds', 75, 'Fog', 85, 'Rain', 95, 'Thunderstorms'] },
+        { id: 'lakeland', region: 'norvrandt', zh: '雷克蘭德', en: 'Lakeland', ja: 'レイクランド', weatherTable: ['Clear Skies', 20, 'Fair Skies', 60, 'Clouds', 75, 'Fog', 85, 'Rain', 95, 'Thunderstorms'] },
+        { id: 'kholusia', region: 'norvrandt', zh: '珂露西亞島', en: 'Kholusia', ja: 'コルシア島', weatherTable: ['Clear Skies', 15, 'Fair Skies', 55, 'Clouds', 70, 'Fog', 80, 'Rain', 90, 'Thunderstorms'] },
+        { id: 'amh-araeng', region: 'norvrandt', zh: '安穆·艾蘭', en: 'Amh Araeng', ja: 'アム・アレーン', weatherTable: ['Fair Skies', 45, 'Clouds', 60, 'Dust Storms', 70, 'Heat Waves', 80, 'Clear Skies'] },
+        { id: 'il-mheg', region: 'norvrandt', zh: '伊爾美格', en: 'Il Mheg', ja: 'イル・メグ', weatherTable: ['Clear Skies', 10, 'Fair Skies', 45, 'Clouds', 60, 'Fog', 75, 'Rain', 90, 'Thunderstorms'] },
+        { id: 'rak-tika', region: 'norvrandt', zh: '拉凱提卡大森林', en: "The Rak'tika Greatwood", ja: 'ラケティカ大森林', weatherTable: ['Fog', 10, 'Rain', 20, 'Umbral Wind', 30, 'Clear Skies', 45, 'Fair Skies', 85, 'Clouds'] },
+        { id: 'tempest', region: 'norvrandt', zh: '黑風海', en: 'The Tempest', ja: 'テンペスト', weatherTable: ['Clear Skies', 20, 'Fair Skies', 80, 'Clouds'] },
+        { id: 'eulmore', region: 'norvrandt', zh: '遊末邦', en: 'Eulmore', ja: 'ユールモア', weatherTable: ['Gales', 10, 'Rain', 20, 'Fog', 30, 'Clouds', 45, 'Fair Skies', 85, 'Clear Skies'] },
+
+        // Ilsabard
+        { id: 'radz-at-han', region: 'ilsabard', zh: '拉札罕', en: 'Radz-at-Han', ja: 'ラザハン', weatherTable: ['Fog', 15, 'Rain', 25, 'Clear Skies', 55, 'Fair Skies', 85, 'Clouds'] },
+        { id: 'thavnair', region: 'ilsabard', zh: '薩維奈島', en: 'Thavnair', ja: 'サベネア島', weatherTable: ['Fog', 10, 'Rain', 17, 'Showers', 25, 'Clear Skies', 55, 'Fair Skies', 85, 'Clouds'] },
+        { id: 'garlemald', region: 'ilsabard', zh: '加雷馬', en: 'Garlemald', ja: 'ガレマルド', weatherTable: ['Snow', 45, 'Thunder', 50, 'Rain', 55, 'Fog', 60, 'Clouds', 70, 'Fair Skies', 85, 'Clear Skies'] },
+
+        // The Sea of Stars
+        { id: 'old-sharlayan', region: 'the-sea-of-stars', zh: '舊薩雷安', en: 'Old Sharlayan', ja: 'オールド・シャーレアン', weatherTable: ['Clear Skies', 10, 'Fair Skies', 50, 'Clouds', 70, 'Fog', 85, 'Rain'] },
+        { id: 'labyrinthos', region: 'the-sea-of-stars', zh: '迷津', en: 'Labyrinthos', ja: 'ラヴィリンソス', weatherTable: ['Clear Skies', 15, 'Fair Skies', 60, 'Clouds'] },
+        { id: 'mare-lamentorum', region: 'the-sea-of-stars', zh: '嘆息海', en: 'Mare Lamentorum', ja: '嘆きの海', weatherTable: ['Moon Dust', 50, 'Fair Skies', 90, 'Umbral Wind'] },
+        { id: 'ultima-thule', region: 'the-sea-of-stars', zh: '厄爾庇斯', en: 'Ultima Thule', ja: 'ウルティマ・トゥーレ', weatherTable: ['Astromagnetic Storm', 20, 'Fair Skies', 55, 'Umbral Wind'] },
+
+        // The World Unsundered
+        { id: 'elpis', region: 'the-world-unsundered', zh: '艾爾庇斯', en: 'Elpis', ja: 'エルピス', weatherTable: ['Clear Skies', 25, 'Fair Skies', 70, 'Clouds', 80, 'Fog', 90, 'Umbral Wind'] },
+
+        // Tural
+        { id: 'tuliyollal', region: 'tural', zh: '圖莉尤拉爾', en: 'Tuliyollal', ja: 'トライヨラ', weatherTable: ['Clouds', 5, 'Rain', 15, 'Fog', 25, 'Fair Skies', 60, 'Clear Skies'] },
+        { id: 'solution-nine', region: 'tural', zh: '九號解決方案', en: 'Solution Nine', ja: 'ソリューション・ナイン', weatherTable: ['Fair Skies', 50, 'Clouds', 80, 'Rain'] },
+        { id: 'urqopacha', region: 'tural', zh: '奧爾卡帕查', en: 'Urqopacha', ja: 'オルコパチャ', weatherTable: ['Clear Skies', 20, 'Fair Skies', 60, 'Clouds', 80, 'Fog', 90, 'Rain'] },
+        { id: 'kozamauka', region: 'tural', zh: '科薩馬爾卡', en: "Kozama'uka", ja: 'コザマル・カ', weatherTable: ['Rain', 15, 'Showers', 25, 'Fog', 35, 'Clouds', 50, 'Fair Skies', 80, 'Clear Skies'] },
+        { id: 'yak-tel', region: 'tural', zh: '雅克·特爾', en: "Yak T'el", ja: 'ヤクテル樹海', weatherTable: ['Rain', 20, 'Fog', 35, 'Clouds', 50, 'Fair Skies', 80, 'Clear Skies'] },
+        { id: 'shaaloani', region: 'tural', zh: '夏勞尼', en: 'Shaaloani', ja: 'シャーローニ荒野', weatherTable: ['Dust Storms', 10, 'Clear Skies', 50, 'Fair Skies', 80, 'Clouds'] },
+        { id: 'heritage-found', region: 'tural', zh: '發現遺產', en: 'Heritage Found', ja: 'ヘリテージファウンド', weatherTable: ['Thunderstorms', 5, 'Rain', 15, 'Fog', 25, 'Clouds', 45, 'Fair Skies', 80, 'Clear Skies'] },
+        { id: 'living-memory', region: 'tural', zh: '活記憶', en: 'Living Memory', ja: 'リビング・メモリー', weatherTable: ['Rain', 10, 'Fog', 20, 'Fair Skies', 60, 'Clear Skies'] },
+
+        // Special / Miscellaneous
+        { id: 'wolves-den-pier', region: 'la-noscea', zh: '狼獄演習場', en: "Wolves' Den Pier", ja: 'ウルヴズジェイル演習場', weatherTable: ['Clear Skies', 20, 'Fair Skies', 50, 'Clouds', 70, 'Fog', 80, 'Wind', 90, 'Rain'] },
+        { id: 'eureka-anemos', region: 'othard', zh: '恆冰之地', en: 'Eureka Anemos', ja: '禁断の地 エウレカ：アネモス帯', weatherTable: ['Fair Skies', 30, 'Gales', 60, 'Showers', 90, 'Snow'] },
+        { id: 'eureka-pagos', region: 'othard', zh: '恆冰之地', en: 'Eureka Pagos', ja: '禁断の地 エウレカ：パゴス帯', weatherTable: ['Clear Skies', 10, 'Fog', 28, 'Heat Waves', 46, 'Snow', 64, 'Thunder', 82, 'Blizzards'] },
+        { id: 'eureka-pyros', region: 'othard', zh: '涌火之地', en: 'Eureka Pyros', ja: '禁断の地 エウレカ：ピューロス帯', weatherTable: ['Fair Skies', 10, 'Heat Waves', 28, 'Thunder', 46, 'Blizzards', 64, 'Umbral Wind', 82, 'Snow'] },
+        { id: 'eureka-hydatos', region: 'othard', zh: '湧水之地', en: 'Eureka Hydatos', ja: '禁断の地 エウレカ：ヒュダトス帯', weatherTable: ['Fair Skies', 12, 'Showers', 34, 'Gloom', 56, 'Thunderstorms', 78, 'Snow'] },
+        { id: 'bozjan-southern-front', region: 'ilsabard', zh: '博茲雅戰線南方戰區', en: 'The Bozjan Southern Front', ja: 'ボズヤ戦線', weatherTable: ['Fair Skies', 20, 'Rain', 40, 'Wind', 60, 'Thunder', 80, 'Dust Storms'] },
+        { id: 'zadnor', region: 'ilsabard', zh: '扎杜諾爾高原', en: 'Zadnor', ja: 'ザトゥノル高原', weatherTable: ['Fair Skies', 15, 'Rain', 30, 'Wind', 50, 'Thunder', 70, 'Snow', 85, 'Gales'] },
+        { id: 'diadem', region: 'abalathia', zh: '雲冠群島', en: 'The Diadem', ja: 'ディアデム諸島', weatherTable: ['Clear Skies', 20, 'Fair Skies', 50, 'Clouds', 70, 'Fog', 80, 'Wind', 90, 'Umbral Wind'] }
+    ],
+
+    /**
+     * Get zone by ID
+     * @param {string} zoneId - Zone ID
+     * @returns {object|null} Zone data or null if not found
+     */
+    getZone(zoneId) {
+        return this.zones.find(z => z.id === zoneId) || null;
+    },
+
+    /**
+     * Get all zones in a region
+     * @param {string} regionId - Region ID
+     * @returns {array} Array of zones in the region
+     */
+    getZonesByRegion(regionId) {
+        return this.zones.filter(z => z.region === regionId);
+    },
+
+    /**
+     * Get zones grouped by region
+     * @returns {object} Object with region IDs as keys and zone arrays as values
+     */
+    getZonesGroupedByRegion() {
+        const grouped = {};
+        for (const zone of this.zones) {
+            if (!grouped[zone.region]) {
+                grouped[zone.region] = [];
+            }
+            grouped[zone.region].push(zone);
+        }
+        return grouped;
+    },
+
+    /**
+     * Get weather info
+     * @param {string} weatherName - Weather name in English
+     * @returns {object|null} Weather info or null if not found
+     */
+    getWeatherInfo(weatherName) {
+        return this.weatherTypes[weatherName] || null;
+    },
+
+    /**
+     * Get all unique weather types used across all zones
+     * @returns {array} Array of unique weather names
+     */
+    getAllUsedWeatherTypes() {
+        const weatherSet = new Set();
+        for (const zone of this.zones) {
+            const table = zone.weatherTable;
+            for (let i = 0; i < table.length; i += 2) {
+                weatherSet.add(table[i]);
+            }
+            // Last weather (no chance value after it)
+            if (table.length % 2 === 1) {
+                weatherSet.add(table[table.length - 1]);
+            }
+        }
+        return Array.from(weatherSet).sort();
+    }
+};
+
+// Export for use in other modules
+window.WeatherZoneData = WeatherZoneData;


### PR DESCRIPTION
## Summary

- Add new Weather Forecast tool that allows players to view upcoming weather for any zone in FFXIV
- Support 78 zones across 14 regions with accurate weather tables
- Implement deterministic weather calculation algorithm
- Add multi-select filtering for target weather, previous weather, and ET time range
- Include URL hash synchronization for shareable links

## Features

- **78 Zones**: Complete coverage of all FFXIV regions (La Noscea, Black Shroud, Thanalan, Coerthas, etc.)
- **Real-time Display**: Shows current Eorzea Time and local time
- **Weather Filtering**: Multi-select tags for target and previous weather conditions
- **Time Range**: Visual 24-hour grid for ET time range filtering
- **Timetable View**: Shows upcoming weather when no filters active
- **Search Results**: Displays matching weather windows with pagination
- **Shareable Links**: URL hash sync preserves filter state
- **i18n Support**: Chinese, English, and Japanese translations
- **Dark Mode**: Full dark mode support
- **Responsive**: Mobile-friendly design

## Test plan

- [ ] Open `http://localhost:8000/tools/weather-forecast/` in browser
- [ ] Test zone selection for multiple zones across different regions
- [ ] Test weather filtering (single and multi-select)
- [ ] Test time range selection (including wrap-around like 22:00-06:00)
- [ ] Test URL hash routing (share link, browser back button)
- [ ] Test dark mode toggle
- [ ] Test language switching (zh/en/ja)
- [ ] Verify responsive design on mobile/tablet

🤖 Generated with [Claude Code](https://claude.ai/code)