### PR TITLE
feat(lodestone): mark tool as unavailable for TW version

### DIFF
--- a/assets/js/i18n/translations/index.js
+++ b/assets/js/i18n/translations/index.js
@@ -52,7 +52,7 @@ const IndexTranslations = {
         tool_equipment_analyzer_desc: '分析裝備屬性和配裝建議，提供最佳配裝方案',
 
         // 狀態標籤
-        status_coming_soon: '即將推出',
+        status_coming_soon: '⏳ 即將推出',
         status_under_construction: '🚧 施工中',
         status_unavailable: '⚠️ 繁中版不支援'
     },
@@ -106,7 +106,7 @@ const IndexTranslations = {
         tool_equipment_analyzer_desc: 'Analyze equipment stats and provide optimal gear recommendations',
 
         // Status badges
-        status_coming_soon: 'Coming Soon',
+        status_coming_soon: '⏳ Coming Soon',
         status_under_construction: '🚧 WIP',
         status_unavailable: '⚠️ Not Available (TW)'
     },
@@ -160,7 +160,7 @@ const IndexTranslations = {
         tool_equipment_analyzer_desc: '装備ステータスを分析し、最適な装備を提案',
 
         // ステータスバッジ
-        status_coming_soon: '近日公開',
+        status_coming_soon: '⏳ 近日公開',
         status_under_construction: '🚧 工事中',
         status_unavailable: '⚠️ 繁体字版未対応'
     }

--- a/assets/js/i18n/translations/index.js
+++ b/assets/js/i18n/translations/index.js
@@ -53,7 +53,8 @@ const IndexTranslations = {
 
         // 狀態標籤
         badge_coming_soon: '即將推出',
-        badge_under_construction: '施工中'
+        badge_under_construction: '施工中',
+        badge_unavailable: '繁中版不支援'
     },
     en: {
         // Page info
@@ -106,7 +107,8 @@ const IndexTranslations = {
 
         // Status badges
         badge_coming_soon: 'Coming Soon',
-        badge_under_construction: 'WIP'
+        badge_under_construction: 'WIP',
+        badge_unavailable: 'Not Available (TW)'
     },
     ja: {
         // ページ情報
@@ -159,7 +161,8 @@ const IndexTranslations = {
 
         // ステータスバッジ
         badge_coming_soon: '近日公開',
-        badge_under_construction: '工事中'
+        badge_under_construction: '工事中',
+        badge_unavailable: '繁体字版未対応'
     }
 };
 

--- a/assets/js/i18n/translations/index.js
+++ b/assets/js/i18n/translations/index.js
@@ -52,9 +52,9 @@ const IndexTranslations = {
         tool_equipment_analyzer_desc: '分析裝備屬性和配裝建議，提供最佳配裝方案',
 
         // 狀態標籤
-        badge_coming_soon: '即將推出',
-        badge_under_construction: '施工中',
-        badge_unavailable: '繁中版不支援'
+        status_coming_soon: '即將推出',
+        status_under_construction: '🚧 施工中',
+        status_unavailable: '⚠️ 繁中版不支援'
     },
     en: {
         // Page info
@@ -106,9 +106,9 @@ const IndexTranslations = {
         tool_equipment_analyzer_desc: 'Analyze equipment stats and provide optimal gear recommendations',
 
         // Status badges
-        badge_coming_soon: 'Coming Soon',
-        badge_under_construction: 'WIP',
-        badge_unavailable: 'Not Available (TW)'
+        status_coming_soon: 'Coming Soon',
+        status_under_construction: '🚧 WIP',
+        status_unavailable: '⚠️ Not Available (TW)'
     },
     ja: {
         // ページ情報
@@ -160,9 +160,9 @@ const IndexTranslations = {
         tool_equipment_analyzer_desc: '装備ステータスを分析し、最適な装備を提案',
 
         // ステータスバッジ
-        badge_coming_soon: '近日公開',
-        badge_under_construction: '工事中',
-        badge_unavailable: '繁体字版未対応'
+        status_coming_soon: '近日公開',
+        status_under_construction: '🚧 工事中',
+        status_unavailable: '⚠️ 繁体字版未対応'
     }
 };
 

--- a/changelog.html
+++ b/changelog.html
@@ -55,6 +55,7 @@
                                 <li><span class="tag tag-success">新增</span> 天氣預報：可過濾目標天氣、前置天氣與艾歐澤亞時間範圍</li>
                                 <li><span class="tag tag-success">新增</span> 天氣預報：即時顯示目前 ET 時間與本地時間</li>
                                 <li><span class="tag tag-success">新增</span> 天氣預報：支援 URL 分享，可分享搜尋條件</li>
+                                <li><span class="tag tag-info">優化</span> Lodestone 角色查詢：標記為繁中版不支援（FF14 繁中版無 Lodestone 功能）</li>
                             </ul>
                         </div>
                     </article>

--- a/index.html
+++ b/index.html
@@ -167,6 +167,10 @@
             box-shadow: 0 2px 8px rgba(255, 152, 0, 0.3);
         }
 
+        .status-badge.unavailable {
+            background: #6c757d;
+        }
+
         .tool-icon {
             font-size: 3.5rem;
             margin-bottom: 1.5rem;
@@ -356,7 +360,7 @@
                     </a>
 
                     <a href="tools/lodestone-lookup/index.html" class="tool-card available">
-                        <span class="status-badge under-construction" data-i18n="status_under_construction">🚧 施工中</span>
+                        <span class="status-badge unavailable" data-i18n="status_unavailable">⚠️ 繁中版不支援</span>
                         <div class="tool-icon">🔍</div>
                         <h3 class="tool-title" data-i18n="tool_lodestone_title">Lodestone 角色查詢</h3>
                         <p class="tool-description" data-i18n="tool_lodestone_desc">使用 Lodestone ID 查詢 FF14 角色資訊，查看職業等級與成就</p>

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
         }
 
         .status-badge.unavailable {
-            background: #6c757d;
+            background: var(--text-secondary);
         }
 
         .tool-icon {
@@ -360,7 +360,7 @@
                     </a>
 
                     <a href="tools/lodestone-lookup/index.html" class="tool-card available">
-                        <span class="status-badge unavailable" data-i18n="status_unavailable">⚠️ 繁中版不支援</span>
+                        <span class="status-badge unavailable" data-i18n="badge_unavailable">⚠️ 繁中版不支援</span>
                         <div class="tool-icon">🔍</div>
                         <h3 class="tool-title" data-i18n="tool_lodestone_title">Lodestone 角色查詢</h3>
                         <p class="tool-description" data-i18n="tool_lodestone_desc">使用 Lodestone ID 查詢 FF14 角色資訊，查看職業等級與成就</p>

--- a/index.html
+++ b/index.html
@@ -360,7 +360,7 @@
                     </a>
 
                     <a href="tools/lodestone-lookup/index.html" class="tool-card available">
-                        <span class="status-badge unavailable" data-i18n="badge_unavailable">⚠️ 繁中版不支援</span>
+                        <span class="status-badge unavailable" data-i18n="status_unavailable">⚠️ 繁中版不支援</span>
                         <div class="tool-icon">🔍</div>
                         <h3 class="tool-title" data-i18n="tool_lodestone_title">Lodestone 角色查詢</h3>
                         <p class="tool-description" data-i18n="tool_lodestone_desc">使用 Lodestone ID 查詢 FF14 角色資訊，查看職業等級與成就</p>


### PR DESCRIPTION
## Summary
- Mark Lodestone 角色查詢 tool as "繁中版不支援" since FF14 Taiwan version does not support Lodestone
- Add new grey "unavailable" status badge styling
- Add i18n translations for the new badge (zh/en/ja)

## Test plan
- [ ] Open `http://localhost:8000` and verify Lodestone tool card shows grey "⚠️ 繁中版不支援" badge
- [ ] Verify the card remains clickable and navigates to the tool page
- [ ] Test language switching (ZH/EN/JA) to verify badge translations work correctly
- [ ] Check changelog page shows the new entry in v2.10.0

🤖 Generated with [Claude Code](https://claude.ai/claude-code)