### PR TITLE
feat(design): design-system foundation — tokens, shared components, first three tool migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Tools that work without server (can open HTML directly):
 - 角色卡產生器
 - Faux Hollows Foxes 計算機
 
-**No package management, linting, or testing commands** - the project uses vanilla web technologies only.
+**Testing:** `node --test`（Node 內建 test runner，自動執行 `tests/*.test.js`）。`tests/design-system.test.js` 守住設計系統規則（token 完整性、對比度、token-clean 檔案清單）；`tests/pages.test.js` 守住每一頁的載入順序與字型。每次 commit 前執行。沒有 package.json、bundler 或 linter。
 
 ## Core Patterns
 
@@ -134,6 +134,10 @@ HTML Structure:
 3. Import shared CSS/JS in the following order:
    ```html
    <!-- CSS -->
+   <link rel="preconnect" href="https://fonts.googleapis.com">
+   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+   <link rel="stylesheet" href="../../assets/css/tokens.css">
    <link rel="stylesheet" href="../../assets/css/common.css">
    <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
    <link rel="stylesheet" href="../../assets/css/tools-common.css">
@@ -182,6 +186,14 @@ HTML Structure:
 ### Overview
 The project includes a modular CSS component system in `/assets/css/components/` to ensure UI consistency across all tools. **Always use these shared components instead of creating custom styles.**
 
+### Design Tokens (`assets/css/tokens.css`)
+全站唯一的顏色、字級、間距、圓角、陰影來源；深色模式只在 `[data-theme="dark"]` 重新指定顏色類 token。**規則：**
+- 工具的 `style.css` 只寫版面（grid / flex / 間距），不得出現任何色碼（`#hex`、`rgb()`、`white`）、不得引用 `tokens.css` 未定義的 `var(--…)`、不得 `@import`、不得 `!important`；遷移完成的檔案列在 `tests/design-system.test.js` 的 `TOKEN_CLEAN_FILES`。
+- 顏色：`--color-primary`（互動色）、`--color-bg` / `--color-surface` / `--color-surface-2`、`--color-border` / `--color-border-strong`、`--color-heading` / `--color-text` / `--color-muted`、語意色 `--color-{success,warning,danger,info}` 及其 `-tint` / `-text` / `-border`，實心底上的字用 `--color-on-{primary,success,warning,danger,info,muted}`。
+- 字級 9 階 `--text-xs` … `--text-5xl`；間距 `--space-1` … `--space-10`（4px 基底）；圓角 `--radius-{sm,md,lg,xl,full}`；陰影 `--shadow-{sm,md,lg,xl}`；控制項高度 `--control-{sm,md,lg}` = 32 / 40 / 48；動態 `--duration-{fast,base,slow}` + `--ease`。
+- `common.css` 頂部的 `--primary-color`、`--text-color` 等舊名稱只是過渡期的相容別名，新程式碼不要使用。
+- 品牌漸層 `--gradient-brand` 只用在頁首、首頁 hero、工具卡 hover 頂線。
+
 ### Available Components
 
 #### 1. Buttons (`components/buttons.css`)
@@ -191,15 +203,15 @@ The project includes a modular CSS component system in `/assets/css/components/`
 <button class="btn btn-secondary">Secondary Button</button>
 <button class="btn btn-success">Success Button</button>
 <button class="btn btn-danger">Danger Button</button>
-<button class="btn btn-warning">Warning Button</button>
-<button class="btn btn-info">Info Button</button>
 
 <!-- Size variants -->
 <button class="btn btn-primary btn-sm">Small Button</button>
 <button class="btn btn-primary btn-lg">Large Button</button>
 
-<!-- Outline buttons -->
-<button class="btn btn-outline-primary">Outline Primary</button>
+<!-- 輪廓 / 文字 -->
+<button class="btn btn-outline">輪廓按鈕</button>
+<button class="btn btn-ghost">文字按鈕</button>
+<!-- 純 .btn = 次要按鈕；一個畫面最多一顆 .btn-primary -->
 
 <!-- Icon buttons -->
 <button class="btn btn-primary">
@@ -227,7 +239,6 @@ The project includes a modular CSS component system in `/assets/css/components/`
 
 <!-- Hoverable clickable card -->
 <div class="card hoverable clickable">
-    <img class="card-img-top" src="image.jpg" alt="Card image">
     <div class="card-body">
         <h3 class="card-title">Interactive Card</h3>
         <p class="card-text">This card responds to hover and click.</p>
@@ -241,19 +252,9 @@ The project includes a modular CSS component system in `/assets/css/components/`
     <div class="card">...</div>
 </div>
 
-<!-- Horizontal card -->
-<div class="card card-horizontal">
-    <img class="card-img-left" src="image.jpg" alt="Card image">
-    <div class="card-body">
-        <h3 class="card-title">Horizontal Card</h3>
-        <p class="card-text">Content flows horizontally.</p>
-    </div>
-</div>
-
 <!-- Card states -->
 <div class="card card-selected">Selected card</div>
 <div class="card card-disabled">Disabled card</div>
-<div class="card card-loading">Loading card</div>
 ```
 
 #### 3. Loading States (`tools-common.css`)
@@ -323,14 +324,6 @@ The project includes a modular CSS component system in `/assets/css/components/`
     <input type="text" class="form-control search-input" placeholder="搜尋...">
 </div>
 
-<!-- Input group -->
-<div class="input-group">
-    <div class="input-group-prepend">
-        <span class="input-group-text">@</span>
-    </div>
-    <input type="text" class="form-control" placeholder="使用者名稱">
-</div>
-
 <!-- Validation states -->
 <input type="text" class="form-control is-valid">
 <div class="valid-feedback">輸入正確！</div>
@@ -353,18 +346,15 @@ The project includes a modular CSS component system in `/assets/css/components/`
         單選按鈕
     </label>
 </div>
-
-<!-- Range slider -->
-<input type="range" class="form-range" min="0" max="100">
 ```
 
 #### 6. Language Switcher (`components/language-switcher.css`)
 ```html
 <!-- 語言切換器 -->
 <div class="language-switcher" id="languageSwitcher">
-    <button class="lang-btn active" data-lang="zh">🇹🇼 中文</button>
-    <button class="lang-btn" data-lang="en">🇺🇸 EN</button>
-    <button class="lang-btn" data-lang="ja">🇯🇵 日本語</button>
+    <button class="language-btn active" data-lang="zh">🇹🇼 中文</button>
+    <button class="language-btn" data-lang="en">🇺🇸 EN</button>
+    <button class="language-btn" data-lang="ja">🇯🇵 日本語</button>
 </div>
 ```
 
@@ -389,9 +379,11 @@ The project includes a modular CSS component system in `/assets/css/components/`
 <!-- Outline tags -->
 <span class="tag tag-outline-primary">輪廓標籤</span>
 
-<!-- Filter tags (toggleable) -->
-<button class="tag tag-filter">四人迷宮</button>
-<button class="tag tag-filter active">八人副本</button>
+<!-- 篩選膠囊（可切換；.tag-filter 為舊名稱） -->
+<button class="chip">四人迷宮</button>
+<button class="chip active">八人副本</button>
+<!-- 實心狀態徽章 -->
+<span class="tag tag-solid tag-warning">施工中</span>
 
 <!-- Tag groups -->
 <div class="tag-group">
@@ -402,13 +394,6 @@ The project includes a modular CSS component system in `/assets/css/components/`
 
 <!-- Badges -->
 <span class="badge">99+</span>
-<span class="badge badge-circle">5</span>
-
-<!-- Dismissible tag -->
-<span class="tag tag-primary tag-dismissible">
-    可關閉標籤
-    <button class="tag-close">&times;</button>
-</span>
 ```
 
 ### Component Usage Guidelines
@@ -420,7 +405,7 @@ The project includes a modular CSS component system in `/assets/css/components/`
 5. **Maintain consistency** - if a component doesn't meet your needs, consider updating the shared component instead of creating a one-off solution
 
 ### Dark Mode Support
-All components automatically support Dark Mode through `[data-theme="dark"]` selectors. No additional styling needed.
+All components support Dark Mode automatically: `assets/css/tokens.css` redefines every colour token under `[data-theme="dark"]`, and components contain no dark rules of their own（`tests/design-system.test.js` 會擋下元件與已遷移工具內的 `[data-theme=` 規則）。需要調整深色外觀時改 token，不要在元件或工具加 `[data-theme="dark"]` 覆寫。
 
 ### Responsive Design
 Components include responsive breakpoints:
@@ -487,9 +472,9 @@ i18n.addObserver(() => this.updateUI());
 <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
 
 <div class="language-switcher" id="languageSwitcher">
-    <button class="lang-btn active" data-lang="zh">🇹🇼 中文</button>
-    <button class="lang-btn" data-lang="en">🇺🇸 EN</button>
-    <button class="lang-btn" data-lang="ja">🇯🇵 日本語</button>
+    <button class="language-btn active" data-lang="zh">🇹🇼 中文</button>
+    <button class="language-btn" data-lang="en">🇺🇸 EN</button>
+    <button class="language-btn" data-lang="ja">🇯🇵 日本語</button>
 </div>
 ```
 

--- a/about.html
+++ b/about.html
@@ -6,11 +6,12 @@
     <title>關於我們 - FF14.tw</title>
     <meta name="description" content="了解 FF14.tw 的理念與貢獻者們">
     <link rel="icon" type="image/x-icon" href="assets/images/ff14tw.ico">
-    <link rel="stylesheet" href="assets/css/common.css">
-    <link rel="stylesheet" href="assets/css/components/language-switcher.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/tokens.css">
+    <link rel="stylesheet" href="assets/css/common.css">
+    <link rel="stylesheet" href="assets/css/components/language-switcher.css">
     <style>
         .about-content {
             max-width: 900px;

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -1,51 +1,31 @@
-/* FF14.tw 共用樣式 */
+/* ==========================================================================
+   FF14.tw 共用樣式 — 版面基礎、頁首、導覽、頁尾
+   顏色與尺寸一律來自 assets/css/tokens.css（每一頁都在本檔之前載入）
+   ========================================================================== */
 
+/* --------------------------------------------------------------------------
+   舊 token 名稱 → 新 token 的相容別名層
+   只為了尚未遷移的工具而存在，工具全部遷移完成後整段刪除（Plan 3）。
+   新程式碼一律直接使用 tokens.css 的名稱，不要再引用這些舊名稱。
+   -------------------------------------------------------------------------- */
 :root {
-    --primary-color: #4a90e2;
-    --secondary-color: #f39c12;
-    --accent-color: #e74c3c;
-    --dark-color: #2c3e50;
-    --light-color: #ecf0f1;
-    --text-color: #333;
-    --border-color: #ddd;
-    --shadow: 0 2px 10px rgba(0,0,0,0.1);
-    --gradient-bg: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    
-    /* 新增變數以支援更好的主題切換 */
-    --bg-color: #f5f7fa;
-    --bg-secondary: #ffffff;
-    --text-secondary: #666;
-    --header-shadow: 0 2px 10px rgba(0,0,0,0.1);
-    --card-bg: #ffffff;
-    --hover-bg: rgba(0,0,0,0.05);
-    --dropdown-bg: #ffffff;
-    --dropdown-shadow: 0 8px 16px rgba(0,0,0,0.2);
-    --nav-hover: rgba(255,255,255,0.2);
-    --nav-active: rgba(255,255,255,0.3);
-}
-
-/* Dark mode 變數定義 */
-[data-theme="dark"] {
-    --primary-color: #5a9ff0;
-    --secondary-color: #f5a623;
-    --accent-color: #ff6b6b;
-    --dark-color: #1a1d2e;
-    --light-color: #2d3142;
-    --text-color: #e8e8e8;
-    --border-color: #3d4154;
-    --shadow: 0 2px 10px rgba(0,0,0,0.3);
-    --gradient-bg: linear-gradient(135deg, #4a5568 0%, #2d3748 100%);
-    
-    --bg-color: #0f1419;
-    --bg-secondary: #1a1d2e;
-    --text-secondary: #a0a0a0;
-    --header-shadow: 0 2px 10px rgba(0,0,0,0.5);
-    --card-bg: #1a1d2e;
-    --hover-bg: rgba(255,255,255,0.05);
-    --dropdown-bg: #2d3142;
-    --dropdown-shadow: 0 8px 16px rgba(0,0,0,0.5);
-    --nav-hover: rgba(255,255,255,0.1);
-    --nav-active: rgba(255,255,255,0.2);
+    --primary-color: var(--color-primary);
+    --secondary-color: var(--color-warning);
+    --accent-color: var(--color-danger);
+    --dark-color: var(--color-heading);
+    --light-color: var(--color-surface-2);
+    --text-color: var(--color-text);
+    --text-secondary: var(--color-muted);
+    --border-color: var(--color-border);
+    --shadow: var(--shadow-md);
+    --header-shadow: var(--shadow-md);
+    --gradient-bg: var(--gradient-brand);
+    --bg-color: var(--color-bg);
+    --bg-secondary: var(--color-surface);
+    --card-bg: var(--color-surface);
+    --hover-bg: var(--color-hover);
+    --dropdown-bg: var(--color-surface);
+    --dropdown-shadow: var(--shadow-lg);
 }
 
 * {
@@ -55,23 +35,29 @@
 }
 
 body {
-    font-family: 'Noto Sans TC', 'Microsoft JhengHei', sans-serif;
-    line-height: 1.6;
-    color: var(--text-color);
-    background-color: #f5f7fa;
+    font-family: var(--font-sans);
+    font-size: var(--text-md);
+    line-height: var(--leading-normal);
+    color: var(--color-text);
+    background-color: var(--color-bg);
 }
 
 .container {
-    max-width: 1200px;
+    max-width: var(--container-max);
     margin: 0 auto;
-    padding: 0 20px;
+    padding: 0 var(--container-gutter);
+}
+
+/* 窄版內容區（表單型工具）：取代各工具自訂的 700 / 800 / 900px */
+.container-narrow {
+    max-width: var(--container-narrow);
+    margin: 0 auto;
 }
 
 /* 視覺隱藏但保留給螢幕閱讀器和 SEO
  * 使用時機：
  * - 需要為螢幕閱讀器提供內容，但視覺上不需要顯示
  * - 需要保留 SEO 的 H1 標籤，但視覺上已由導航欄顯示
- * - 跳過導航連結等可訪問性增強元素
  * 注意：不要使用 display:none 或 visibility:hidden，這會讓螢幕閱讀器也無法讀取
  */
 .visually-hidden {
@@ -86,65 +72,103 @@ body {
     border: 0;
 }
 
-/* 標題樣式 */
-h1, h2, h3 {
-    margin-bottom: 1rem;
-    font-weight: 600;
+/* 標題：字級只用 tokens.css 的 9 階 */
+h1,
+h2,
+h3 {
+    margin-bottom: var(--space-4);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-snug);
+    color: var(--color-heading);
 }
 
 h1 {
-    font-size: 2.5rem;
-    color: var(--dark-color);
+    font-size: var(--text-4xl);
+    font-weight: var(--weight-bold);
+    line-height: var(--leading-tight);
 }
 
 h2 {
-    font-size: 2rem;
-    color: var(--primary-color);
+    font-size: var(--text-2xl);
 }
 
 h3 {
-    font-size: 1.5rem;
+    font-size: var(--text-xl);
 }
 
-/* 頁首 */
+a {
+    color: var(--color-primary);
+}
+
+a:hover {
+    color: var(--color-primary-hover);
+}
+
+/* 原生表單元素的基礎（未遷移工具的深色模式相容；.form-control 另有完整樣式） */
+input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]):not([type="file"]):not([type="submit"]):not([type="button"]),
+select,
+textarea {
+    font-family: inherit;
+    color: var(--color-text);
+    background-color: var(--color-surface);
+    border-color: var(--color-border-strong);
+}
+
+input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]):not([type="file"]):not([type="submit"]):not([type="button"]):focus,
+select:focus,
+textarea:focus {
+    border-color: var(--color-primary);
+    outline: none;
+    box-shadow: var(--ring-primary);
+}
+
+/* 頁首（不建立 stacking context：手機版的 .nav / .hamburger 要能疊在 body 層的 .nav-overlay 之上） */
 .header {
-    background: var(--gradient-bg);
-    color: white;
-    padding: 1rem 0;
-    box-shadow: var(--shadow);
+    background: var(--header-bg);
+    color: var(--header-text);
+    box-shadow: var(--shadow-md);
 }
 
 .header .container {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: var(--space-4);
+    min-height: 64px;
 }
 
 .logo {
-    font-size: 1.8rem;
-    font-weight: bold;
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    color: var(--header-text);
     text-decoration: none;
-    color: white;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    font-size: var(--text-3xl);
+    font-weight: var(--weight-bold);
+    line-height: 1;
+    white-space: nowrap;
+}
+
+.logo:hover {
+    color: var(--header-text);
 }
 
 .logo-main {
-    font-size: 1.8rem;
+    font-size: inherit;
+}
+
+.logo-separator,
+.logo-tool,
+.logo-tool-name {
+    font-size: var(--text-xl);
+    font-weight: var(--weight-normal);
 }
 
 .logo-separator {
-    font-size: 1.4rem;
     opacity: 0.7;
 }
 
-.logo-tool {
-    font-size: 1.4rem;
-    font-weight: normal;
-}
-
-/* 工具頁面標題隱藏 */
+/* 工具頁面標題隱藏（工具名稱顯示在 logo 旁） */
 .tool-page-title {
     display: none;
 }
@@ -152,152 +176,113 @@ h3 {
 /* 工具頁面描述文字置中 */
 .description {
     text-align: center;
-    color: var(--text-secondary);
-    font-size: 1.1rem;
-    margin-bottom: 2rem;
+    color: var(--color-muted);
+    font-size: var(--text-lg);
+    margin-bottom: var(--space-7);
 }
 
 .nav {
     display: flex;
-    gap: 2rem;
+    align-items: center;
+    gap: var(--space-2);
 }
 
 .nav a {
-    color: white;
+    color: var(--header-text);
     text-decoration: none;
-    padding: 0.5rem 1rem;
-    border-radius: 5px;
-    transition: background-color 0.3s;
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-md);
+    line-height: 1.5;
+    white-space: nowrap;
+    transition: background-color var(--duration-base) var(--ease);
 }
 
 .nav a:hover {
-    background-color: rgba(255,255,255,0.2);
+    background-color: var(--nav-hover);
+    color: var(--header-text);
 }
 
 .nav a.active {
-    background-color: rgba(255,255,255,0.3);
-    font-weight: 600;
+    background-color: var(--nav-active);
+    font-weight: var(--weight-semibold);
 }
 
 /* 主要內容區域 */
 .main {
     min-height: calc(100vh - 120px);
-    padding: 2rem 0;
+    padding: var(--space-7) 0;
 }
 
-/* 工具卡片 */
+/* 首頁、關於、版權聲明的 hero：淺色版仍由各頁內嵌樣式定義（Plan 3 收回這裡），
+   深色版在此以 token 覆寫，避免深色模式出現淺色漸層 */
+[data-theme="dark"] .hero {
+    background: var(--hero-bg);
+    box-shadow: var(--hero-shadow);
+}
+
+/* 首頁工具卡（index.html 目前仍以內嵌樣式覆寫；Plan 3 會把內嵌樣式收回這裡） */
 .tools-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-    margin-top: 2rem;
+    gap: var(--space-7);
+    margin-top: var(--space-7);
 }
 
 .tool-card {
-    background: white;
-    border-radius: 10px;
-    padding: 2rem;
-    box-shadow: var(--shadow);
-    transition: transform 0.3s, box-shadow 0.3s;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-7) var(--space-6);
+    box-shadow: var(--shadow-md);
     text-decoration: none;
     color: inherit;
+    transition: transform var(--duration-slow) var(--ease), box-shadow var(--duration-slow) var(--ease), border-color var(--duration-slow) var(--ease);
 }
 
 .tool-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 5px 20px rgba(0,0,0,0.15);
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--color-primary);
 }
 
 .tool-icon {
-    width: 60px;
-    height: 60px;
-    background: var(--gradient-bg);
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 1rem;
-    font-size: 1.5rem;
-    color: white;
+    font-size: var(--text-5xl);
+    line-height: 1;
+    text-align: center;
+    margin-bottom: var(--space-3);
 }
 
 .tool-title {
-    font-size: 1.3rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-    color: var(--dark-color);
+    font-size: var(--text-xl);
+    font-weight: var(--weight-semibold);
+    margin-bottom: var(--space-2);
+    color: var(--color-heading);
 }
 
 .tool-description {
-    color: #666;
-    line-height: 1.5;
-}
-
-/* 按鈕樣式 */
-.btn {
-    display: inline-block;
-    padding: 0.8rem 2rem;
-    background: var(--primary-color);
-    color: white;
-    text-decoration: none;
-    border-radius: 5px;
-    border: none;
-    cursor: pointer;
-    transition: background-color 0.3s;
-    font-size: 1rem;
-}
-
-.btn:hover {
-    background: #357abd;
-}
-
-.btn-secondary {
-    background: var(--secondary-color);
-}
-
-.btn-secondary:hover {
-    background: #d68910;
-}
-
-.btn-primary {
-    background: var(--primary-color);
-}
-
-.btn-primary:hover {
-    background: #357abd;
-}
-
-.btn-success {
-    background: #28a745;
-}
-
-.btn-success:hover {
-    background: #218838;
-}
-
-.btn-danger {
-    background: #dc3545;
-}
-
-.btn-danger:hover {
-    background: #c82333;
-}
-
-.btn-info {
-    background: #17a2b8;
-}
-
-.btn-info:hover {
-    background: #138496;
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
 }
 
 /* 頁尾 */
 .footer {
-    background: var(--dark-color);
-    color: white;
+    background: var(--footer-bg);
+    color: var(--footer-text);
     text-align: center;
-    padding: 1.5rem 0;
+    padding: var(--space-6) 0;
     margin-top: auto;
+    font-size: var(--text-sm);
+}
+
+.footer a {
+    color: var(--footer-text);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
+.footer a:hover {
+    color: var(--header-text);
 }
 
 /* 漢堡選單按鈕 */
@@ -306,7 +291,7 @@ h3 {
     background: none;
     border: none;
     cursor: pointer;
-    padding: 0.5rem;
+    padding: var(--space-2);
     z-index: 1002;
 }
 
@@ -314,9 +299,9 @@ h3 {
     display: block;
     width: 25px;
     height: 3px;
-    background-color: white;
+    background-color: var(--header-text);
     margin: 5px 0;
-    transition: transform 0.3s, opacity 0.3s;
+    transition: transform var(--duration-slow) var(--ease), opacity var(--duration-slow) var(--ease);
 }
 
 .hamburger.active span:nth-child(1) {
@@ -331,134 +316,20 @@ h3 {
     transform: rotate(-45deg) translate(7px, -6px);
 }
 
-/* 響應式設計 */
-@media (max-width: 768px) {
-    .header .container {
-        position: relative;
-        padding-right: 60px; /* 為漢堡選單預留空間 */
-    }
-    
-    .hamburger {
-        display: block;
-        position: absolute;
-        right: 20px;
-        top: 50%;
-        transform: translateY(-50%);
-    }
-    
-    .nav {
-        display: none;
-        position: fixed;
-        top: 0;
-        right: -100%;
-        width: 250px;
-        height: 100vh;
-        background: var(--gradient-bg);
-        flex-direction: column;
-        padding: 4rem 2rem 2rem;
-        gap: 1rem;
-        box-shadow: -5px 0 15px rgba(0,0,0,0.3);
-        transition: right 0.3s ease;
-        z-index: 1001;
-        overflow-y: auto;
-    }
-    
-    .nav.active {
-        display: flex;
-        right: 0;
-    }
-    
-    .nav a {
-        width: 100%;
-        text-align: left;
-        padding: 0.75rem 1rem;
-        border-radius: 5px;
-    }
-
-    /* 遮罩層 */
-    .nav-overlay {
-        display: none;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0,0,0,0.5);
-        z-index: 1000;
-    }
-    
-    .nav-overlay.active {
-        display: block;
-    }
-    
-    h1 {
-        font-size: 2rem;
-    }
-    
-    .logo {
-        font-size: 1.4rem;
-        display: flex;
-        align-items: center;
-        gap: 0.3rem;
-    }
-    
-    .logo-main {
-        font-size: 1.4rem;
-    }
-    
-    .logo-separator {
-        font-size: 1.2rem;
-    }
-    
-    .logo-tool {
-        font-size: 1.2rem;
-    }
-    
-    .tools-grid {
-        grid-template-columns: 1fr;
-        gap: 1rem;
-    }
-}
-
-/* 小螢幕調整 */
-@media (max-width: 480px) {
-    .logo {
-        font-size: 1.2rem;
-        gap: 0.2rem;
-    }
-    
-    .logo-main {
-        font-size: 1.2rem;
-    }
-    
-    .logo-separator {
-        font-size: 1rem;
-    }
-    
-    .logo-tool {
-        font-size: 1rem;
-    }
-    
-    .header .container {
-        padding-right: 50px;
-    }
-}
-
 /* Dark mode 切換按鈕 */
 .theme-toggle {
-    background: none;
-    border: none;
-    color: white;
-    cursor: pointer;
-    padding: 0.5rem;
-    border-radius: 5px;
-    transition: background-color 0.3s;
-    font-size: 1.2rem;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
+    width: var(--control-md);
+    height: var(--control-md);
+    background: none;
+    border: none;
+    border-radius: var(--radius-md);
+    color: var(--header-text);
+    cursor: pointer;
+    padding: 0;
+    transition: background-color var(--duration-base) var(--ease);
 }
 
 .theme-toggle:hover {
@@ -483,22 +354,22 @@ h3 {
 /* 返回頂部按鈕 */
 .back-to-top {
     position: fixed;
-    bottom: 20px;
-    right: 20px;
-    background: var(--primary-color);
-    color: white;
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
+    bottom: var(--space-5);
+    right: var(--space-5);
     display: flex;
     align-items: center;
     justify-content: center;
+    width: var(--control-lg);
+    height: var(--control-lg);
+    background: var(--color-primary);
+    color: var(--color-on-primary);
+    border-radius: var(--radius-full);
     text-decoration: none;
-    box-shadow: var(--shadow);
+    box-shadow: var(--shadow-lg);
     opacity: 0;
     visibility: hidden;
-    transition: opacity 0.3s, visibility 0.3s, transform 0.3s;
-    z-index: 999;
+    transition: opacity var(--duration-slow) var(--ease), visibility var(--duration-slow) var(--ease), transform var(--duration-base) var(--ease), box-shadow var(--duration-base) var(--ease);
+    z-index: var(--z-overlay);
 }
 
 .back-to-top.show {
@@ -507,80 +378,118 @@ h3 {
 }
 
 .back-to-top:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 5px 20px rgba(0,0,0,0.2);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-xl);
+    color: var(--color-on-primary);
 }
 
-/* 響應式調整主題按鈕 */
+/* 響應式設計 */
 @media (max-width: 768px) {
+    .header .container {
+        position: relative;
+        padding-right: 60px; /* 為漢堡選單預留空間 */
+    }
+
+    .hamburger {
+        display: block;
+        position: absolute;
+        right: var(--container-gutter);
+        top: 50%;
+        transform: translateY(-50%);
+    }
+
     .theme-toggle {
         position: absolute;
         right: 60px;
         top: 50%;
         transform: translateY(-50%);
     }
+
+    .nav {
+        display: none;
+        position: fixed;
+        top: 0;
+        right: -100%;
+        width: 250px;
+        height: 100vh;
+        background: var(--header-bg);
+        flex-direction: column;
+        align-items: stretch;
+        padding: var(--space-10) var(--space-7) var(--space-7);
+        gap: var(--space-2);
+        box-shadow: var(--shadow-xl);
+        transition: right var(--duration-slow) var(--ease);
+        z-index: 1001;
+        overflow-y: auto;
+    }
+
+    .nav.active {
+        display: flex;
+        right: 0;
+    }
+
+    .nav a {
+        width: 100%;
+        text-align: left;
+        padding: var(--space-3) var(--space-4);
+    }
+
+    /* 遮罩層 */
+    .nav-overlay {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: var(--color-overlay);
+        z-index: var(--z-overlay);
+    }
+
+    .nav-overlay.active {
+        display: block;
+    }
+
+    h1 {
+        font-size: var(--text-3xl);
+    }
+
+    .logo {
+        font-size: var(--text-xl);
+        gap: var(--space-1);
+    }
+
+    .logo-separator,
+    .logo-tool,
+    .logo-tool-name {
+        font-size: var(--text-md);
+    }
+
+    .tools-grid {
+        grid-template-columns: 1fr;
+        gap: var(--space-4);
+    }
 }
 
-/* Dark mode 特定調整 */
-[data-theme="dark"] body {
-    background-color: var(--bg-color);
+@media (max-width: 480px) {
+    .header .container {
+        padding-right: 50px;
+    }
+
+    .logo {
+        font-size: var(--text-lg);
+    }
+
+    .logo-separator,
+    .logo-tool,
+    .logo-tool-name {
+        font-size: var(--text-sm);
+    }
 }
 
-[data-theme="dark"] .hero {
-    background: linear-gradient(135deg, #2d3748 0%, #1a202c 100%);
-}
-
-[data-theme="dark"] .tool-card:hover {
-    box-shadow: 0 5px 20px rgba(255,255,255,0.1);
-}
-
-[data-theme="dark"] .btn:not(.theme-toggle) {
-    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-}
-
-[data-theme="dark"] .btn-primary:hover {
-    background: #6bb1f5;
-}
-
-[data-theme="dark"] .btn-secondary:hover {
-    background: #f7b84a;
-}
-
-[data-theme="dark"] .btn-success:hover {
-    background: #34d058;
-}
-
-[data-theme="dark"] .btn-danger:hover {
-    background: #ff7b7b;
-}
-
-[data-theme="dark"] .btn-info:hover {
-    background: #20c9e6;
-}
-
-[data-theme="dark"] input,
-[data-theme="dark"] select,
-[data-theme="dark"] textarea {
-    background-color: var(--bg-secondary);
-    color: var(--text-color);
-    border-color: var(--border-color);
-}
-
-[data-theme="dark"] input:focus,
-[data-theme="dark"] select:focus,
-[data-theme="dark"] textarea:focus {
-    border-color: var(--primary-color);
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(90, 159, 240, 0.2);
-}
-
-[data-theme="dark"] .back-to-top:hover {
-    box-shadow: 0 5px 20px rgba(255,255,255,0.2);
-}
-
-/* 確保過渡動畫順暢 */
+/* 主題切換時的過渡 */
 * {
-    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+    transition: background-color var(--duration-slow) var(--ease), color var(--duration-slow) var(--ease), border-color var(--duration-slow) var(--ease);
 }
 
 /* 排除不需要過渡的元素 */
@@ -590,21 +499,34 @@ h3 {
     transition: none;
 }
 
+@media (prefers-reduced-motion: reduce) {
+    *,
+    .tool-card,
+    .back-to-top {
+        transition: none;
+    }
+
+    .tool-card:hover,
+    .back-to-top:hover {
+        transform: none;
+    }
+}
+
 /* ============================
    佈局載入器樣式 - 防止 FOUC
    ============================ */
-
 #header-placeholder,
 #footer-placeholder {
     min-height: 60px;
 }
 
 #header-placeholder {
-    background: var(--gradient-bg);
+    min-height: 64px;
+    background: var(--header-bg);
 }
 
 #footer-placeholder {
-    background: var(--dark-color);
+    background: var(--footer-bg);
 }
 
 /* 載入完成後的過渡效果 */
@@ -616,22 +538,4 @@ body.layout-loaded .footer {
 @keyframes layoutFadeIn {
     from { opacity: 0.8; }
     to { opacity: 1; }
-}
-
-/* 工具頁面 Logo 樣式（用於動態載入） */
-.logo-tool-name {
-    font-size: 1.4rem;
-    font-weight: normal;
-}
-
-@media (max-width: 768px) {
-    .logo-tool-name {
-        font-size: 1.2rem;
-    }
-}
-
-@media (max-width: 480px) {
-    .logo-tool-name {
-        font-size: 1rem;
-    }
 }

--- a/assets/css/components/buttons.css
+++ b/assets/css/components/buttons.css
@@ -1,201 +1,206 @@
-/* ===================================
-   按鈕元件樣式 (Button Components)
-   =================================== */
-
-/* 基礎按鈕樣式 */
+/* ==========================================================================
+   按鈕 — 規格：設計系統畫布「元件 01 按鈕」
+   高度 sm 32 / md 40 / lg 48；同一畫面最多一顆 .btn-primary。
+   純 .btn（無變體）= 次要按鈕。
+   ========================================================================== */
 .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1.5rem;
-    border: none;
-    border-radius: 6px;
-    font-size: 1rem;
-    font-weight: 500;
+    gap: var(--space-2);
+    height: var(--control-md);
+    padding: 0 var(--space-5);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-heading);
+    font-family: var(--font-sans);
+    font-size: var(--text-md);
+    font-weight: var(--weight-medium);
     line-height: 1;
-    cursor: pointer;
-    text-decoration: none;
     white-space: nowrap;
-    transition: all 0.2s ease;
-    position: relative;
-    overflow: hidden;
-    background-color: var(--gray-200, #e9ecef);
-    color: var(--gray-700, #495057);
+    text-decoration: none;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color var(--duration-base) var(--ease), border-color var(--duration-base) var(--ease), color var(--duration-base) var(--ease), box-shadow var(--duration-base) var(--ease), transform var(--duration-base) var(--ease);
 }
 
-/* 按鈕尺寸變體 */
-.btn-sm {
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    gap: 0.375rem;
-}
-
-.btn-lg {
-    padding: 1rem 2rem;
-    font-size: 1.125rem;
-    gap: 0.625rem;
-}
-
-/* 按鈕顏色變體 */
-.btn-primary {
-    background-color: var(--primary-color, #4a90e2);
-    color: white;
-}
-
-.btn-secondary {
-    background-color: var(--secondary-color, #6c757d);
-    color: white;
-}
-
-.btn-success {
-    background-color: var(--success-color, #28a745);
-    color: white;
-}
-
-.btn-danger {
-    background-color: var(--danger-color, #dc3545);
-    color: white;
-}
-
-.btn-warning {
-    background-color: var(--warning-color, #ffc107);
-    color: var(--gray-900, #212529);
-}
-
-.btn-info {
-    background-color: var(--info-color, #17a2b8);
-    color: white;
-}
-
-/* 按鈕狀態 - Hover */
 .btn:hover:not(:disabled) {
+    background: var(--color-surface-2);
+    color: var(--color-heading);
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-md);
+}
+
+.btn:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: var(--shadow-sm);
+}
+
+.btn:focus-visible {
+    outline: none;
+    box-shadow: var(--ring-primary);
+}
+
+.btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+/* 主要 */
+.btn-primary {
+    background: var(--color-primary);
+    border-color: transparent;
+    color: var(--color-on-primary);
 }
 
 .btn-primary:hover:not(:disabled) {
-    background-color: var(--primary-dark, #357abd);
+    background: var(--color-primary-hover);
+    color: var(--color-on-primary);
+}
+
+.btn-primary:active:not(:disabled) {
+    background: var(--color-primary-active);
+}
+
+/* 次要（與純 .btn 相同，保留名稱給既有標記） */
+.btn-secondary {
+    background: var(--color-surface);
+    border-color: var(--color-border-strong);
+    color: var(--color-heading);
 }
 
 .btn-secondary:hover:not(:disabled) {
-    background-color: var(--secondary-dark, #545b62);
+    background: var(--color-surface-2);
 }
 
-.btn-success:hover:not(:disabled) {
-    background-color: var(--success-dark, #1e7e34);
+/* 輪廓 */
+.btn-outline,
+.btn-outline-primary,
+.btn-outline-secondary {
+    background: transparent;
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.btn-outline:hover:not(:disabled),
+.btn-outline-primary:hover:not(:disabled),
+.btn-outline-secondary:hover:not(:disabled) {
+    background: var(--color-primary-tint);
+    color: var(--color-primary);
+}
+
+/* 文字 */
+.btn-ghost {
+    background: transparent;
+    border-color: transparent;
+    color: var(--color-primary);
+}
+
+.btn-ghost:hover:not(:disabled) {
+    background: var(--color-primary-tint);
+    color: var(--color-primary);
+    transform: none;
+    box-shadow: none;
+}
+
+/* 危險 */
+.btn-danger {
+    background: var(--color-danger);
+    border-color: transparent;
+    color: var(--color-on-danger);
 }
 
 .btn-danger:hover:not(:disabled) {
-    background-color: var(--danger-dark, #bd2130);
+    background: var(--color-danger);
+    color: var(--color-on-danger);
+    filter: brightness(0.92);
 }
 
-.btn-warning:hover:not(:disabled) {
-    background-color: var(--warning-dark, #e0a800);
-}
-
-.btn-info:hover:not(:disabled) {
-    background-color: var(--info-dark, #117a8b);
-}
-
-/* 按鈕狀態 - Active */
-.btn:active:not(:disabled) {
-    transform: translateY(0);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-/* 按鈕狀態 - Focus */
-.btn:focus {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.25);
-}
-
-.btn-danger:focus {
-    box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.25);
-}
-
-.btn-success:focus {
-    box-shadow: 0 0 0 3px rgba(40, 167, 69, 0.25);
-}
-
-/* 按鈕狀態 - Disabled */
-.btn:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-    transform: none;
-}
-
-/* 輪廓按鈕變體 */
-.btn-outline-primary {
-    background-color: transparent;
-    color: var(--primary-color, #4a90e2);
-    border: 2px solid var(--primary-color, #4a90e2);
-}
-
-.btn-outline-primary:hover:not(:disabled) {
-    background-color: var(--primary-color, #4a90e2);
-    color: white;
-}
-
-.btn-outline-secondary {
-    background-color: transparent;
-    color: var(--secondary-color, #6c757d);
-    border: 2px solid var(--secondary-color, #6c757d);
-}
-
-.btn-outline-secondary:hover:not(:disabled) {
-    background-color: var(--secondary-color, #6c757d);
-    color: white;
+.btn-danger:focus-visible {
+    box-shadow: var(--ring-danger);
 }
 
 .btn-outline-danger {
-    background-color: transparent;
-    color: var(--danger-color, #dc3545);
-    border: 2px solid var(--danger-color, #dc3545);
+    background: transparent;
+    border-color: var(--color-danger);
+    color: var(--color-danger-text);
 }
 
 .btn-outline-danger:hover:not(:disabled) {
-    background-color: var(--danger-color, #dc3545);
-    color: white;
+    background: var(--color-danger-tint);
+    color: var(--color-danger-text);
 }
 
-/* 圖標按鈕支援 */
+/* 成功（動作完成的回饋，例如「已複製」） */
+.btn-success {
+    background: var(--color-success);
+    border-color: transparent;
+    color: var(--color-on-success);
+}
+
+.btn-success:hover:not(:disabled) {
+    background: var(--color-success);
+    color: var(--color-on-success);
+    filter: brightness(0.92);
+}
+
+/* 尺寸 */
+.btn-sm {
+    height: var(--control-sm);
+    padding: 0 var(--space-4);
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+}
+
+.btn-lg {
+    height: var(--control-lg);
+    padding: 0 var(--space-7);
+    font-size: var(--text-lg);
+}
+
+.btn-block {
+    display: flex;
+    width: 100%;
+}
+
+/* 圖示（既有標記把 emoji 放在 <span class="btn-icon">） */
 .btn-icon {
     font-size: 1.1em;
+    line-height: 1;
 }
 
 .btn-icon-only {
-    padding: 0.75rem;
-    gap: 0;
+    width: var(--control-md);
+    padding: 0;
 }
 
 .btn-icon-only.btn-sm {
-    padding: 0.5rem;
+    width: var(--control-sm);
 }
 
 .btn-icon-only.btn-lg {
-    padding: 1rem;
+    width: var(--control-lg);
 }
 
-/* 按鈕組 */
+/* 按鈕群組 */
 .btn-group {
     display: inline-flex;
-    gap: 0.5rem;
+    flex-wrap: wrap;
+    gap: var(--space-2);
 }
 
 .btn-group-vertical {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: var(--space-2);
 }
 
-/* 全寬按鈕 */
-.btn-block {
-    width: 100%;
-}
-
-/* 載入狀態 */
+/* 載入中 */
 .btn-loading {
+    position: relative;
     color: transparent;
     pointer-events: none;
 }
@@ -203,94 +208,58 @@
 .btn-loading::after {
     content: "";
     position: absolute;
-    width: 1rem;
-    height: 1rem;
     top: 50%;
     left: 50%;
-    margin-left: -0.5rem;
-    margin-top: -0.5rem;
-    border: 2px solid #f3f3f3;
-    border-top: 2px solid currentColor;
-    border-radius: 50%;
-    animation: btn-spinner 0.6s linear infinite;
+    width: 18px;
+    height: 18px;
+    margin: -9px 0 0 -9px;
+    border: 2px solid transparent;
+    border-top-color: var(--color-heading);
+    border-radius: var(--radius-full);
+    animation: btn-spinner 0.8s linear infinite;
+}
+
+.btn-primary.btn-loading::after {
+    border-top-color: var(--color-on-primary);
+}
+
+.btn-danger.btn-loading::after {
+    border-top-color: var(--color-on-danger);
+}
+
+.btn-success.btn-loading::after {
+    border-top-color: var(--color-on-success);
 }
 
 @keyframes btn-spinner {
     to { transform: rotate(360deg); }
 }
 
-/* 特殊按鈕樣式 */
+/* 關閉（×） */
 .btn-close {
-    padding: 0.5rem;
+    width: var(--control-sm);
+    height: var(--control-sm);
+    padding: 0;
+    border-color: transparent;
     background: transparent;
-    color: var(--gray-600, #6c757d);
-    font-size: 1.5rem;
+    color: var(--color-muted);
+    font-size: var(--text-2xl);
     line-height: 1;
-    border-radius: 4px;
 }
 
-.btn-close:hover {
-    background-color: var(--gray-100, #f8f9fa);
-    color: var(--gray-900, #212529);
+.btn-close:hover:not(:disabled) {
+    background: var(--color-surface-2);
+    color: var(--color-heading);
+    transform: none;
+    box-shadow: none;
 }
 
-/* Dark Mode 支援 */
-[data-theme="dark"] .btn {
-    background-color: var(--dark-gray-700, #343a40);
-    color: var(--dark-gray-100, #f8f9fa);
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
-}
+@media (prefers-reduced-motion: reduce) {
+    .btn {
+        transition: none;
+    }
 
-[data-theme="dark"] .btn-primary {
-    background-color: var(--primary-color, #4a90e2);
-    color: white;
-}
-
-[data-theme="dark"] .btn-primary:hover:not(:disabled) {
-    background-color: #6bb1f5;
-}
-
-[data-theme="dark"] .btn-secondary {
-    background-color: var(--secondary-color, #6c757d);
-    color: white;
-}
-
-[data-theme="dark"] .btn-secondary:hover:not(:disabled) {
-    background-color: #8b959e;
-}
-
-[data-theme="dark"] .btn-success:hover:not(:disabled) {
-    background-color: #34d058;
-}
-
-[data-theme="dark"] .btn-danger:hover:not(:disabled) {
-    background-color: #ff7b7b;
-}
-
-[data-theme="dark"] .btn-warning {
-    background-color: var(--warning-color, #ffc107);
-    color: var(--gray-900, #212529);
-}
-
-[data-theme="dark"] .btn-warning:hover:not(:disabled) {
-    background-color: #f7b84a;
-}
-
-[data-theme="dark"] .btn-info:hover:not(:disabled) {
-    background-color: #20c9e6;
-}
-
-[data-theme="dark"] .btn-outline-primary,
-[data-theme="dark"] .btn-outline-secondary,
-[data-theme="dark"] .btn-outline-danger {
-    background-color: transparent;
-}
-
-[data-theme="dark"] .btn-close {
-    color: var(--dark-gray-400, #ced4da);
-}
-
-[data-theme="dark"] .btn-close:hover {
-    background-color: var(--dark-gray-800, #212529);
-    color: var(--dark-gray-100, #f8f9fa);
+    .btn:hover:not(:disabled) {
+        transform: none;
+    }
 }

--- a/assets/css/components/cards.css
+++ b/assets/css/components/cards.css
@@ -1,172 +1,117 @@
-/* ===================================
-   卡片元件樣式 (Card Components)
-   =================================== */
-
-/* 基礎卡片樣式 */
+/* ==========================================================================
+   卡片與面板 — 規格：設計系統畫布「元件 04 卡片與面板」
+   所有「白底、圓角、陰影」的容器都是同一個卡片。
+   ========================================================================== */
 .card {
-    background: var(--card-bg, white);
-    border-radius: var(--border-radius-lg, 12px);
-    box-shadow: var(--card-shadow, 0 2px 8px rgba(0, 0, 0, 0.08));
+    display: flex;
+    flex-direction: column;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
     overflow: hidden;
-    transition: all 0.3s ease;
-    position: relative;
-    border: 1px solid var(--card-border, #e9ecef);
+    transition: transform var(--duration-slow) var(--ease), box-shadow var(--duration-slow) var(--ease), border-color var(--duration-slow) var(--ease);
 }
 
-/* 卡片懸停效果 */
-.card-hover:hover,
-.card.hoverable:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--card-hover-shadow, 0 8px 24px rgba(0, 0, 0, 0.12));
-}
-
-/* 可點擊卡片 */
-.card-clickable,
-.card.clickable {
-    cursor: pointer;
-}
-
-/* 卡片內容區域 */
 .card-header {
-    padding: 1.25rem 1.5rem;
-    border-bottom: 1px solid var(--card-border, #e9ecef);
-    background: var(--card-header-bg, #f8f9fa);
+    padding: 14px var(--space-6);
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface-2);
+    font-size: var(--text-md);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
 }
 
 .card-body {
-    padding: 1.5rem;
+    flex: 1 1 auto;
+    padding: var(--space-6);
 }
 
 .card-footer {
-    padding: 1rem 1.5rem;
-    border-top: 1px solid var(--card-border, #e9ecef);
-    background: var(--card-footer-bg, #f8f9fa);
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-6);
+    border-top: 1px solid var(--color-border);
+    background: var(--color-surface-2);
 }
 
-/* 無邊框卡片 */
-.card-borderless {
-    border: none;
-}
-
-/* 卡片尺寸變體 */
+/* 小卡片 */
 .card-sm .card-body {
-    padding: 1rem;
+    padding: var(--space-4);
 }
 
 .card-sm .card-header,
 .card-sm .card-footer {
-    padding: 0.75rem 1rem;
+    padding: var(--space-2) var(--space-4);
 }
 
-.card-lg .card-body {
-    padding: 2rem;
-}
-
-.card-lg .card-header,
-.card-lg .card-footer {
-    padding: 1.5rem 2rem;
-}
-
-/* 卡片圖片 */
-.card-img-top {
-    width: 100%;
-    height: auto;
-    border-top-left-radius: calc(var(--border-radius-lg, 12px) - 1px);
-    border-top-right-radius: calc(var(--border-radius-lg, 12px) - 1px);
-}
-
-.card-img-bottom {
-    width: 100%;
-    height: auto;
-    border-bottom-left-radius: calc(var(--border-radius-lg, 12px) - 1px);
-    border-bottom-right-radius: calc(var(--border-radius-lg, 12px) - 1px);
-}
-
-.card-img-overlay {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    padding: 1.5rem;
-}
-
-/* 卡片網格佈局 */
-.card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 1.5rem;
-}
-
-.card-grid-sm {
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 1rem;
-}
-
-.card-grid-lg {
-    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-    gap: 2rem;
-}
-
-/* 卡片列表佈局 */
-.card-list {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-/* 水平卡片 */
-.card-horizontal {
-    display: flex;
-    flex-direction: row;
-}
-
-.card-horizontal .card-img-left {
-    flex-shrink: 0;
-    width: 200px;
-    border-radius: var(--border-radius-lg, 12px) 0 0 var(--border-radius-lg, 12px);
-}
-
-.card-horizontal .card-body {
-    flex: 1;
-}
-
-/* 卡片標題樣式 */
+/* 卡片內文字 */
 .card-title {
-    margin: 0 0 0.75rem 0;
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--card-title-color, #212529);
+    margin: 0 0 var(--space-3);
+    font-size: var(--text-xl);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-snug);
+    color: var(--color-heading);
 }
 
 .card-subtitle {
-    margin: -0.375rem 0 0.75rem 0;
-    font-size: 0.875rem;
-    color: var(--text-muted, #6c757d);
+    margin: calc(-1 * var(--space-2)) 0 var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--color-muted);
 }
 
 .card-text {
-    margin-bottom: 1rem;
-    color: var(--card-text-color, #495057);
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    color: var(--color-text);
 }
 
-/* 卡片連結 */
+.card-text:last-child {
+    margin-bottom: 0;
+}
+
 .card-link {
-    color: var(--primary-color, #4a90e2);
+    color: var(--color-primary);
     text-decoration: none;
-    margin-right: 1rem;
+    margin-right: var(--space-4);
 }
 
 .card-link:hover {
     text-decoration: underline;
 }
 
-/* 卡片動作區域 */
+/* 可點擊 / hover */
+.card-clickable,
+.card.clickable {
+    cursor: pointer;
+}
+
+.card-hover:hover,
+.card.hoverable:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--color-primary);
+}
+
+/* 狀態 */
+.card-selected {
+    border-color: var(--color-primary);
+    box-shadow: var(--ring-primary);
+}
+
+.card-disabled {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+/* 動作區 */
 .card-actions {
     display: flex;
-    gap: 0.5rem;
-    padding: 1rem 1.5rem;
-    border-top: 1px solid var(--card-border, #e9ecef);
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-6);
+    border-top: 1px solid var(--color-border);
 }
 
 .card-actions-vertical {
@@ -185,61 +130,73 @@
     justify-content: space-between;
 }
 
-/* 卡片狀態 */
-.card-selected {
-    border-color: var(--primary-color, #4a90e2);
-    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.2);
+/* 版面 */
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: var(--space-6);
 }
 
-.card-disabled {
-    opacity: 0.6;
-    pointer-events: none;
+.card-grid-sm {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: var(--space-4);
 }
 
-/* 卡片載入狀態 */
-.card-loading {
-    position: relative;
-    overflow: hidden;
+.card-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
 }
 
-.card-loading::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(
-        90deg,
-        transparent,
-        rgba(255, 255, 255, 0.4),
-        transparent
-    );
-    animation: card-loading 1.5s infinite;
+/* 說明面板：圖示 + 標題 + 一段文字 */
+.info-panel {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-5);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
 }
 
-@keyframes card-loading {
-    0% {
-        left: -100%;
-    }
-    100% {
-        left: 100%;
-    }
+.info-panel-icon {
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    margin-top: 2px;
+    color: var(--color-muted);
 }
 
-/* 響應式設計 */
+.info-panel-title {
+    margin: 0 0 var(--space-1);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
+}
+
+.info-panel-text {
+    margin: 0;
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    color: var(--color-muted);
+}
+
+/* 圖片佔位（資料尚無圖片時） */
+.card-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 140px;
+    background: linear-gradient(135deg, var(--color-primary-tint) 0%, var(--color-surface-2) 100%);
+    color: var(--color-muted);
+    font-size: var(--text-xs);
+}
+
 @media (max-width: 768px) {
     .card-grid {
         grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    }
-    
-    .card-horizontal {
-        flex-direction: column;
-    }
-    
-    .card-horizontal .card-img-left {
-        width: 100%;
-        border-radius: var(--border-radius-lg, 12px) var(--border-radius-lg, 12px) 0 0;
     }
 }
 
@@ -247,39 +204,26 @@
     .card-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .card-body {
-        padding: 1rem;
+        padding: var(--space-4);
+    }
+
+    .card-header,
+    .card-footer,
+    .card-actions {
+        padding-left: var(--space-4);
+        padding-right: var(--space-4);
     }
 }
 
-/* Dark Mode 支援 */
-[data-theme="dark"] .card {
-    background: var(--dark-card-bg, #2d3748);
-    border-color: var(--dark-card-border, #4a5568);
-    color: var(--dark-text-color, #e2e8f0);
-}
+@media (prefers-reduced-motion: reduce) {
+    .card {
+        transition: none;
+    }
 
-[data-theme="dark"] .card-header,
-[data-theme="dark"] .card-footer {
-    background: var(--dark-card-header-bg, #1a202c);
-    border-color: var(--dark-card-border, #4a5568);
-}
-
-[data-theme="dark"] .card-title {
-    color: var(--dark-card-title-color, #f7fafc);
-}
-
-[data-theme="dark"] .card-text {
-    color: var(--dark-card-text-color, #cbd5e0);
-}
-
-[data-theme="dark"] .card-hover:hover,
-[data-theme="dark"] .card.hoverable:hover {
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-}
-
-[data-theme="dark"] .card-selected {
-    border-color: var(--primary-color, #4a90e2);
-    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.3);
+    .card-hover:hover,
+    .card.hoverable:hover {
+        transform: none;
+    }
 }

--- a/assets/css/components/forms.css
+++ b/assets/css/components/forms.css
@@ -1,10 +1,9 @@
-/* ===================================
-   表單元件樣式 (Form Components)
-   =================================== */
-
-/* 表單群組 */
+/* ==========================================================================
+   表單控制項 — 規格：設計系統畫布「元件 03 表單」
+   輸入框、下拉、按鈕同高（sm 32 / md 40 / lg 48），焦點環一致。
+   ========================================================================== */
 .form-group {
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--space-6);
 }
 
 .form-group:last-child {
@@ -13,327 +12,193 @@
 
 .form-label {
     display: block;
-    margin-bottom: 0.5rem;
-    font-weight: 500;
-    color: var(--text-color, #212529);
+    margin-bottom: var(--space-2);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    color: var(--color-heading);
 }
 
 .form-label.required::after {
     content: " *";
-    color: var(--danger-color, #dc3545);
+    color: var(--color-danger);
 }
 
-/* 基礎輸入框樣式 */
+/* 輸入框 */
 .form-control {
     display: block;
     width: 100%;
-    padding: 0.75rem 1rem;
-    font-size: 1rem;
+    height: var(--control-md);
+    padding: 0 var(--space-3);
+    font-family: var(--font-sans);
+    font-size: var(--text-md);
     line-height: 1.5;
-    color: var(--text-color, #495057);
-    background-color: var(--input-bg, #fff);
+    color: var(--color-text);
+    background-color: var(--color-surface);
     background-clip: padding-box;
-    border: 1px solid var(--border-color, #ced4da);
-    border-radius: var(--border-radius, 6px);
-    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--radius-md);
+    transition: border-color var(--duration-fast) var(--ease), box-shadow var(--duration-fast) var(--ease);
 }
 
-/* 輸入框焦點狀態 */
+.form-control::placeholder {
+    color: var(--color-muted);
+    opacity: 1;
+}
+
 .form-control:focus {
-    color: var(--text-color, #495057);
-    background-color: var(--input-bg, #fff);
-    border-color: var(--primary-color, #4a90e2);
+    color: var(--color-text);
+    background-color: var(--color-surface);
+    border-color: var(--color-primary);
     outline: 0;
-    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.25);
+    box-shadow: var(--ring-primary);
 }
 
-/* 輸入框禁用狀態 */
 .form-control:disabled,
 .form-control[readonly] {
-    background-color: var(--input-disabled-bg, #e9ecef);
-    opacity: 1;
+    background-color: var(--color-surface-2);
+    color: var(--color-muted);
     cursor: not-allowed;
 }
 
-/* 輸入框尺寸變體 */
+/* 尺寸 */
 .form-control-sm {
-    padding: 0.5rem 0.75rem;
-    font-size: 0.875rem;
-    border-radius: var(--border-radius-sm, 4px);
+    height: var(--control-sm);
+    padding: 0 var(--space-3);
+    font-size: var(--text-sm);
 }
 
 .form-control-lg {
-    padding: 1rem 1.25rem;
-    font-size: 1.125rem;
-    border-radius: var(--border-radius-lg, 8px);
+    height: var(--control-lg);
+    padding: 0 var(--space-4);
+    font-size: var(--text-lg);
 }
 
-/* 文字區域 */
+/* 多行文字 */
 textarea.form-control {
-    min-height: calc(1.5em + 1.5rem + 2px);
+    height: auto;
+    min-height: calc(var(--control-md) * 2.4);
+    padding: var(--space-2) var(--space-3);
     resize: vertical;
 }
 
-/* 選擇框 */
+/* 下拉：箭頭用兩段漸層畫出，顏色跟 token */
 select.form-control {
-    padding-right: 2.5rem;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 0.75rem center;
-    background-size: 16px 12px;
     appearance: none;
+    padding-right: var(--control-md);
+    background-image:
+        linear-gradient(45deg, transparent 50%, var(--color-muted) 50%),
+        linear-gradient(135deg, var(--color-muted) 50%, transparent 50%);
+    background-position:
+        calc(100% - 18px) 50%,
+        calc(100% - 12px) 50%;
+    background-size: 6px 6px, 6px 6px;
+    background-repeat: no-repeat;
+    cursor: pointer;
 }
 
-/* 檔案輸入 */
-.form-control-file {
-    display: block;
-    width: 100%;
+select.form-control:disabled {
+    cursor: not-allowed;
 }
 
-/* 搜尋框 */
+/* 搜尋框（有圖示時才留左內距） */
 .search-box {
     position: relative;
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--space-6);
 }
 
-.search-input {
-    padding-left: 2.75rem;
+.search-box .search-input {
+    padding-left: var(--control-md);
 }
 
 .search-icon {
     position: absolute;
-    left: 1rem;
+    left: var(--space-3);
     top: 50%;
     transform: translateY(-50%);
-    color: var(--text-muted, #6c757d);
+    color: var(--color-muted);
     pointer-events: none;
 }
 
-/* 輸入群組 */
-.input-group {
-    position: relative;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: stretch;
-    width: 100%;
+/* 說明與驗證 */
+.form-text {
+    display: block;
+    margin-top: var(--space-1);
+    font-size: var(--text-sm);
+    color: var(--color-muted);
 }
 
-.input-group > .form-control {
-    position: relative;
-    flex: 1 1 auto;
-    width: 1%;
-    min-width: 0;
-}
-
-.input-group-prepend,
-.input-group-append {
-    display: flex;
-}
-
-.input-group-text {
-    display: flex;
-    align-items: center;
-    padding: 0.75rem 1rem;
-    font-size: 1rem;
-    font-weight: 400;
-    line-height: 1.5;
-    color: var(--text-color, #495057);
-    text-align: center;
-    white-space: nowrap;
-    background-color: var(--gray-100, #f8f9fa);
-    border: 1px solid var(--border-color, #ced4da);
-}
-
-.input-group-prepend .input-group-text {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-}
-
-.input-group-append .input-group-text {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-}
-
-.input-group > .form-control:not(:first-child) {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-}
-
-.input-group > .form-control:not(:last-child) {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-}
-
-/* 表單驗證狀態 */
 .form-control.is-valid {
-    border-color: var(--success-color, #28a745);
-}
-
-.form-control.is-valid:focus {
-    border-color: var(--success-color, #28a745);
-    box-shadow: 0 0 0 3px rgba(40, 167, 69, 0.25);
+    border-color: var(--color-success);
 }
 
 .form-control.is-invalid {
-    border-color: var(--danger-color, #dc3545);
+    border-color: var(--color-danger);
 }
 
 .form-control.is-invalid:focus {
-    border-color: var(--danger-color, #dc3545);
-    box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.25);
+    border-color: var(--color-danger);
+    box-shadow: var(--ring-danger);
 }
 
-/* 表單提示文字 */
-.form-text {
-    display: block;
-    margin-top: 0.25rem;
-    font-size: 0.875rem;
-    color: var(--text-muted, #6c757d);
-}
-
+.valid-feedback,
 .invalid-feedback {
     display: none;
     width: 100%;
-    margin-top: 0.25rem;
-    font-size: 0.875rem;
-    color: var(--danger-color, #dc3545);
+    margin-top: var(--space-1);
+    font-size: var(--text-sm);
 }
 
+.valid-feedback {
+    color: var(--color-success-text);
+}
+
+.invalid-feedback {
+    color: var(--color-danger-text);
+}
+
+.form-control.is-valid ~ .valid-feedback,
 .form-control.is-invalid ~ .invalid-feedback {
     display: block;
 }
 
-.valid-feedback {
-    display: none;
-    width: 100%;
-    margin-top: 0.25rem;
-    font-size: 0.875rem;
-    color: var(--success-color, #28a745);
-}
-
-.form-control.is-valid ~ .valid-feedback {
-    display: block;
-}
-
-/* 橫向表單 */
-.form-row {
-    display: flex;
-    flex-wrap: wrap;
-    margin-right: -0.5rem;
-    margin-left: -0.5rem;
-}
-
-.form-row > .form-group {
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
-}
-
-/* 內聯表單 */
-.form-inline {
-    display: flex;
-    flex-flow: row wrap;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.form-inline .form-control {
-    display: inline-block;
-    width: auto;
-    vertical-align: middle;
-}
-
-/* 核取方塊和單選按鈕 */
+/* 核取方塊與單選（原生元件，顏色用 accent-color 跟主色） */
 .form-check {
-    position: relative;
-    display: block;
-    padding-left: 1.25rem;
-    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--color-text);
 }
 
 .form-check-input {
-    position: absolute;
-    margin-top: 0.3rem;
-    margin-left: -1.25rem;
+    width: 18px;
+    height: 18px;
+    margin: 0;
+    flex-shrink: 0;
+    accent-color: var(--color-primary);
+    cursor: pointer;
 }
 
 .form-check-label {
-    margin-bottom: 0;
+    margin: 0;
     cursor: pointer;
 }
 
 .form-check-inline {
     display: inline-flex;
+    margin-right: var(--space-3);
+}
+
+/* 橫向表單 */
+.form-inline {
+    display: flex;
+    flex-flow: row wrap;
     align-items: center;
-    padding-left: 0;
-    margin-right: 0.75rem;
+    gap: var(--space-2);
 }
 
-.form-check-inline .form-check-input {
-    position: static;
-    margin-top: 0;
-    margin-right: 0.3125rem;
-    margin-left: 0;
-}
-
-/* 範圍滑桿 */
-.form-range {
-    width: 100%;
-    height: 1.5rem;
-    padding: 0;
-    background-color: transparent;
-    appearance: none;
-}
-
-.form-range:focus {
-    outline: 0;
-}
-
-.form-range::-webkit-slider-thumb {
-    width: 1rem;
-    height: 1rem;
-    background-color: var(--primary-color, #4a90e2);
-    border: 0;
-    border-radius: 1rem;
-    appearance: none;
-}
-
-.form-range::-webkit-slider-runnable-track {
-    width: 100%;
-    height: 0.5rem;
-    color: transparent;
-    cursor: pointer;
-    background-color: var(--gray-300, #dee2e6);
-    border-color: transparent;
-    border-radius: 1rem;
-}
-
-/* Dark Mode 支援 */
-[data-theme="dark"] .form-control {
-    color: var(--dark-text-color, #e2e8f0);
-    background-color: var(--dark-input-bg, #2d3748);
-    border-color: var(--dark-border-color, #4a5568);
-}
-
-[data-theme="dark"] .form-control:focus {
-    background-color: var(--dark-input-bg, #2d3748);
-    border-color: var(--primary-color, #4a90e2);
-}
-
-[data-theme="dark"] .form-control:disabled,
-[data-theme="dark"] .form-control[readonly] {
-    background-color: var(--dark-input-disabled-bg, #1a202c);
-}
-
-[data-theme="dark"] select.form-control {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='%23e2e8f0' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3E%3C/svg%3E");
-}
-
-[data-theme="dark"] .input-group-text {
-    color: var(--dark-text-color, #e2e8f0);
-    background-color: var(--dark-gray-700, #374151);
-    border-color: var(--dark-border-color, #4a5568);
-}
-
-[data-theme="dark"] .form-text {
-    color: var(--dark-text-muted, #9ca3af);
+.form-inline .form-control {
+    display: inline-block;
+    width: auto;
 }

--- a/assets/css/components/language-switcher.css
+++ b/assets/css/components/language-switcher.css
@@ -1,133 +1,87 @@
-/**
- * FF14.tw 語言切換器樣式
- * 位置：導航列右側
- * 支援：深色模式、響應式設計
- */
-
-/* 語言切換器容器 */
+/* ==========================================================================
+   語言切換器（導覽列右側）— 顏色與尺寸來自 tokens.css
+   ========================================================================== */
 .language-switcher {
     display: flex;
-    gap: 0.25rem;
     align-items: center;
-    padding: 0.25rem;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 8px;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    background: var(--lang-bg);
+    border-radius: var(--radius-md);
     backdrop-filter: blur(4px);
 }
 
-/* 語言按鈕 */
 .language-btn {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.25rem;
-    padding: 0.375rem 0.625rem;
+    height: 28px;
+    padding: 0 10px;
     border: none;
+    border-radius: var(--radius-sm);
     background: transparent;
-    color: rgba(255, 255, 255, 0.8);
-    font-size: 0.8125rem;
-    font-weight: 500;
+    color: var(--lang-text);
     font-family: inherit;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.2s ease;
+    font-size: var(--text-xs);
+    font-weight: var(--weight-medium);
     white-space: nowrap;
+    cursor: pointer;
+    transition: background-color var(--duration-base) var(--ease), color var(--duration-base) var(--ease);
 }
 
 .language-btn:hover {
-    background: rgba(255, 255, 255, 0.2);
-    color: white;
-}
-
-.language-btn:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.4);
-}
-
-.language-btn:focus:not(:focus-visible) {
-    box-shadow: none;
+    background: var(--nav-hover);
+    color: var(--header-text);
 }
 
 .language-btn:focus-visible {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.4);
-}
-
-/* 選中狀態 */
-.language-btn.active {
-    background: rgba(255, 255, 255, 0.95);
-    color: var(--dark-color, #2c3e50);
-    font-weight: 600;
-}
-
-.language-btn.active:hover {
-    background: white;
-}
-
-/* 響應式：平板及以上 */
-@media (min-width: 768px) {
-    .language-btn {
-        padding: 0.375rem 0.75rem;
-    }
-}
-
-/* 響應式：手機版 */
-@media (max-width: 767px) {
-    .language-switcher {
-        /* 手機版保持緊湊 */
-        padding: 0.125rem;
-        gap: 0.125rem;
-    }
-
-    .language-btn {
-        padding: 0.375rem 0.5rem;
-    }
-}
-
-/* 導航列摺疊時的樣式（用於 hamburger menu） */
-@media (max-width: 480px) {
-    /* 當導航列顯示為垂直選單時 */
-    .nav.nav-open .language-switcher {
-        width: 100%;
-        justify-content: center;
-        margin: 1rem 0;
-        padding: 0.5rem;
-        background: rgba(255, 255, 255, 0.15);
-    }
-
-    .nav.nav-open .language-btn {
-        padding: 0.5rem 1rem;
-    }
-}
-
-/* 深色模式調整 */
-[data-theme="dark"] .language-switcher {
-    background: rgba(255, 255, 255, 0.08);
-}
-
-[data-theme="dark"] .language-btn {
-    color: rgba(255, 255, 255, 0.7);
-}
-
-[data-theme="dark"] .language-btn:hover {
-    background: rgba(255, 255, 255, 0.15);
-    color: white;
-}
-
-[data-theme="dark"] .language-btn.active {
-    background: rgba(255, 255, 255, 0.9);
-    color: var(--dark-color, #1a1d2e);
-}
-
-/* 動畫效果 */
-.language-btn {
-    transform: translateY(0);
+    outline: none;
+    box-shadow: var(--ring-primary);
 }
 
 .language-btn:active {
     transform: translateY(1px);
 }
 
-/* 無障礙：減少動態效果偏好 */
+/* 選中狀態 */
+.language-btn.active {
+    background: var(--lang-active-bg);
+    color: var(--lang-active-text);
+    font-weight: var(--weight-semibold);
+}
+
+.language-btn.active:hover {
+    background: var(--lang-active-bg);
+    color: var(--lang-active-text);
+}
+
+/* 手機版：緊湊一點 */
+@media (max-width: 768px) {
+    .language-switcher {
+        padding: 2px;
+        gap: 2px;
+    }
+
+    .language-btn {
+        padding: 0 var(--space-2);
+    }
+}
+
+/* 導覽列摺疊成垂直選單時 */
+@media (max-width: 480px) {
+    .nav.active .language-switcher {
+        width: 100%;
+        justify-content: center;
+        margin: var(--space-4) 0;
+        padding: var(--space-2);
+    }
+
+    .nav.active .language-btn {
+        height: var(--control-sm);
+        padding: 0 var(--space-4);
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .language-btn {
         transition: none;

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -1,149 +1,191 @@
-/* ===================================
-   標籤元件樣式 (Tag/Badge Components)
-   =================================== */
+/* ==========================================================================
+   標籤、篩選膠囊、徽章 — 規格：設計系統畫布「元件 02」
+   標籤：4px 圓角、不可點、資訊分類。膠囊：999px 圓角、可切換、固定 32px。
+   徽章：圓形計數。
+   ========================================================================== */
 
-/* 基礎標籤樣式 */
+/* ---- 標籤（柔和底為預設） ---- */
 .tag {
-    display: inline-block;
-    padding: 0.375rem 0.75rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 22px;
+    padding: 0 var(--space-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-2);
+    color: var(--color-muted);
+    font-size: var(--text-xs);
+    font-weight: var(--weight-medium);
     line-height: 1;
-    text-align: center;
     white-space: nowrap;
-    vertical-align: baseline;
-    border-radius: 0.375rem;
-    transition: all 0.2s ease;
-    background-color: var(--gray-200, #e9ecef);
-    color: var(--gray-700, #495057);
+    vertical-align: middle;
 }
 
-/* 藥丸形標籤 */
-.tag-pill {
-    padding-right: 0.875rem;
-    padding-left: 0.875rem;
-    border-radius: 10rem;
-}
-
-/* 標籤尺寸變體 */
 .tag-sm {
-    padding: 0.25rem 0.5rem;
-    font-size: 0.75rem;
+    height: 22px;
+    padding: 0 var(--space-2);
+    font-size: var(--text-xs);
 }
 
+.tag-md,
 .tag-lg {
-    padding: 0.5rem 1rem;
-    font-size: 1rem;
+    height: 28px;
+    padding: 0 10px;
+    font-size: var(--text-sm);
 }
 
-/* 標籤顏色變體 */
+/* 柔和變體 */
 .tag-primary {
-    background-color: var(--primary-color, #4a90e2);
-    color: white;
-}
-
-.tag-secondary {
-    background-color: var(--secondary-color, #6c757d);
-    color: white;
+    background: var(--color-primary-tint);
+    border-color: var(--color-primary-tint);
+    color: var(--color-primary);
 }
 
 .tag-success {
-    background-color: var(--success-color, #28a745);
-    color: white;
-}
-
-.tag-danger {
-    background-color: var(--danger-color, #dc3545);
-    color: white;
+    background: var(--color-success-tint);
+    border-color: var(--color-success-tint);
+    color: var(--color-success-text);
 }
 
 .tag-warning {
-    background-color: var(--warning-color, #ffc107);
-    color: var(--gray-900, #212529);
+    background: var(--color-warning-tint);
+    border-color: var(--color-warning-tint);
+    color: var(--color-warning-text);
+}
+
+.tag-danger {
+    background: var(--color-danger-tint);
+    border-color: var(--color-danger-tint);
+    color: var(--color-danger-text);
 }
 
 .tag-info {
-    background-color: var(--info-color, #17a2b8);
-    color: white;
+    background: var(--color-info-tint);
+    border-color: var(--color-info-tint);
+    color: var(--color-info-text);
 }
 
+/* 舊名稱相容 */
+.tag-secondary,
 .tag-light {
-    background-color: var(--gray-100, #f8f9fa);
-    color: var(--gray-800, #343a40);
+    background: var(--color-surface-2);
+    border-color: var(--color-border);
+    color: var(--color-muted);
 }
 
 .tag-dark {
-    background-color: var(--gray-800, #343a40);
-    color: white;
+    background: var(--color-muted);
+    border-color: var(--color-muted);
+    color: var(--color-on-muted);
 }
 
-/* 輪廓標籤變體 */
-.tag-outline {
-    background-color: transparent;
-    border: 2px solid currentColor;
+/* 實心（狀態徽章：施工中、即將推出…） */
+.tag-solid {
+    background: var(--color-muted);
+    border-color: var(--color-muted);
+    color: var(--color-on-muted);
 }
 
-.tag-outline-primary {
-    color: var(--primary-color, #4a90e2);
-    border-color: var(--primary-color, #4a90e2);
+.tag-solid.tag-primary {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: var(--color-on-primary);
 }
 
-.tag-outline-secondary {
-    color: var(--secondary-color, #6c757d);
-    border-color: var(--secondary-color, #6c757d);
+.tag-solid.tag-success {
+    background: var(--color-success);
+    border-color: var(--color-success);
+    color: var(--color-on-success);
 }
 
-.tag-outline-success {
-    color: var(--success-color, #28a745);
-    border-color: var(--success-color, #28a745);
+.tag-solid.tag-warning {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+    color: var(--color-on-warning);
 }
 
+.tag-solid.tag-danger {
+    background: var(--color-danger);
+    border-color: var(--color-danger);
+    color: var(--color-on-danger);
+}
+
+.tag-solid.tag-info {
+    background: var(--color-info);
+    border-color: var(--color-info);
+    color: var(--color-on-info);
+}
+
+/* 輪廓 */
+.tag-outline,
+.tag-outline-primary,
+.tag-outline-secondary,
+.tag-outline-success,
 .tag-outline-danger {
-    color: var(--danger-color, #dc3545);
-    border-color: var(--danger-color, #dc3545);
+    background: transparent;
+    border-color: var(--color-muted);
+    color: var(--color-muted);
 }
 
-/* 可點擊標籤 */
+.tag-outline.tag-primary,
+.tag-outline-primary {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.tag-outline.tag-success,
+.tag-outline-success {
+    border-color: var(--color-success);
+    color: var(--color-success-text);
+}
+
+.tag-outline.tag-warning {
+    border-color: var(--color-warning);
+    color: var(--color-warning-text);
+}
+
+.tag-outline.tag-danger,
+.tag-outline-danger {
+    border-color: var(--color-danger);
+    color: var(--color-danger-text);
+}
+
+.tag-outline.tag-info {
+    border-color: var(--color-info);
+    color: var(--color-info-text);
+}
+
+/* 狀態點 */
+.tag-dot::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: var(--radius-full);
+    background: currentColor;
+}
+
+.tag-pill {
+    border-radius: var(--radius-full);
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
 .tag-clickable {
     cursor: pointer;
 }
 
 .tag-clickable:hover {
-    filter: brightness(0.9);
-    transform: translateY(-1px);
+    filter: brightness(0.95);
 }
 
-/* 可關閉標籤 */
-.tag-dismissible {
-    padding-right: 2rem;
-    position: relative;
-}
-
-.tag-close {
-    position: absolute;
-    top: 50%;
-    right: 0.5rem;
-    transform: translateY(-50%);
-    font-size: 1.25rem;
-    line-height: 1;
-    color: inherit;
-    opacity: 0.7;
-    cursor: pointer;
-    background: none;
-    border: none;
-    padding: 0;
-}
-
-.tag-close:hover {
-    opacity: 1;
-}
-
-/* 標籤群組 */
-.tag-group {
+/* 群組 */
+.tag-group,
+.chip-group {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
     align-items: center;
+    gap: var(--space-2);
 }
 
 .tag-group-vertical {
@@ -151,53 +193,125 @@
     align-items: flex-start;
 }
 
-/* 過濾標籤（可切換狀態） */
+.tag-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+.tag-list li {
+    margin: 0;
+}
+
+/* ---- 篩選膠囊（可切換；.tag-filter 為舊名稱，必須寫在所有 .tag* 之後） ---- */
+.chip,
 .tag-filter {
-    background: white;
-    border: 2px solid var(--border-color, #dee2e6);
-    color: var(--gray-700, #495057);
-    cursor: pointer;
-}
-
-.tag-filter:hover {
-    background-color: var(--gray-50, #f8f9fa);
-    border-color: var(--primary-color, #4a90e2);
-    color: var(--primary-color, #4a90e2);
-}
-
-.tag-filter.active {
-    background-color: var(--primary-color, #4a90e2);
-    border-color: var(--primary-color, #4a90e2);
-    color: white;
-}
-
-/* 徽章樣式（用於計數等） */
-.badge {
-    display: inline-block;
-    padding: 0.25em 0.6em;
-    font-size: 0.75rem;
-    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: var(--control-sm);
+    padding: 0 var(--space-3);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--radius-full);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
     line-height: 1;
-    text-align: center;
     white-space: nowrap;
-    vertical-align: baseline;
-    border-radius: 0.25rem;
-    background-color: var(--secondary-color, #6c757d);
-    color: white;
+    vertical-align: middle;
+    cursor: pointer;
+    transition: background-color var(--duration-base) var(--ease), border-color var(--duration-base) var(--ease), color var(--duration-base) var(--ease), transform var(--duration-base) var(--ease);
 }
 
-/* 圓形徽章 */
-.badge-circle {
-    padding: 0.5em;
-    border-radius: 50%;
-    min-width: 2em;
-    min-height: 2em;
+.chip:hover,
+.tag-filter:hover {
+    background: var(--color-primary-tint);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+    transform: translateY(-1px);
+}
+
+.chip:focus-visible,
+.tag-filter:focus-visible {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: var(--ring-primary);
+}
+
+.chip.active,
+.tag-filter.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: var(--color-on-primary);
+}
+
+.chip.active:hover,
+.tag-filter.active:hover {
+    background: var(--color-primary-hover);
+    border-color: var(--color-primary-hover);
+    color: var(--color-on-primary);
+}
+
+/* 啟用時前面畫一個勾（純 CSS，不用圖片） */
+.chip.active::before,
+.tag-filter.active::before {
+    content: "";
+    width: 8px;
+    height: 5px;
+    margin-top: -2px;
+    border-left: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(-45deg);
+}
+
+.chip-sm {
+    height: 28px;
+    padding: 0 10px;
+}
+
+/* ---- 計數徽章 ---- */
+.badge {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    border-radius: var(--radius-full);
+    background: var(--color-primary);
+    color: var(--color-on-primary);
+    font-size: var(--text-xs);
+    font-weight: var(--weight-bold);
+    line-height: 1;
+    white-space: nowrap;
+    vertical-align: middle;
 }
 
-/* 徽章位置（配合相對定位容器） */
+.badge-neutral {
+    background: var(--color-muted);
+    color: var(--color-on-muted);
+}
+
+.badge-success {
+    background: var(--color-success);
+    color: var(--color-on-success);
+}
+
+.badge-warning {
+    background: var(--color-warning);
+    color: var(--color-on-warning);
+}
+
+.badge-danger {
+    background: var(--color-danger);
+    color: var(--color-on-danger);
+}
+
 .badge-positioned {
     position: absolute;
     top: 0;
@@ -205,79 +319,21 @@
     transform: translate(50%, -50%);
 }
 
-/* 標籤列表樣式 */
-.tag-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-}
-
-.tag-list li {
-    margin: 0;
-}
-
-/* 動畫效果 */
-@keyframes tag-pulse {
-    0% {
-        box-shadow: 0 0 0 0 currentColor;
-    }
-    70% {
-        box-shadow: 0 0 0 6px rgba(0, 0, 0, 0);
-    }
-    100% {
-        box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
-    }
-}
-
-.tag-pulse {
-    animation: tag-pulse 2s infinite;
-}
-
-/* Dark Mode 支援 */
-[data-theme="dark"] .tag {
-    background-color: var(--dark-gray-700, #374151);
-    color: var(--dark-gray-100, #f3f4f6);
-}
-
-[data-theme="dark"] .tag-light {
-    background-color: var(--dark-gray-800, #1f2937);
-    color: var(--dark-gray-100, #f3f4f6);
-}
-
-[data-theme="dark"] .tag-filter {
-    background-color: var(--dark-gray-800, #1f2937);
-    border-color: var(--dark-border-color, #4b5563);
-    color: var(--dark-text-color, #e5e7eb);
-}
-
-[data-theme="dark"] .tag-filter:hover {
-    background-color: var(--dark-gray-700, #374151);
-    border-color: var(--primary-color, #4a90e2);
-    color: var(--primary-color, #4a90e2);
-}
-
-[data-theme="dark"] .tag-filter.active {
-    background-color: var(--primary-color, #4a90e2);
-    border-color: var(--primary-color, #4a90e2);
-    color: white;
-}
-
-/* 響應式設計 */
 @media (max-width: 480px) {
-    .tag {
-        font-size: 0.75rem;
-        padding: 0.25rem 0.5rem;
+    .tag-group,
+    .chip-group {
+        gap: var(--space-1);
     }
-    
-    .tag-lg {
-        font-size: 0.875rem;
-        padding: 0.375rem 0.75rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .chip,
+    .tag-filter {
+        transition: none;
     }
-    
-    .tag-group {
-        gap: 0.25rem;
+
+    .chip:hover,
+    .tag-filter:hover {
+        transform: none;
     }
 }

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -1,0 +1,217 @@
+/* ==========================================================================
+   FF14.tw 設計 token — 全站唯一的顏色、尺寸、字體來源
+   規格：設計系統畫布「基礎 Foundations」（2026-08-26，方向 A 靛藍統一）
+   規則：
+   1. 元件與工具只能透過 var(--…) 取值，不得再出現色碼。
+   2. 深色模式只在 [data-theme="dark"] 重新指定顏色類 token；
+      元件與工具不再各自撰寫 dark 規則。
+   3. 新增 token 前先確認畫布上沒有可用的值。
+   ========================================================================== */
+
+:root {
+    /* ---- 品牌（只用在頁首、首頁 hero、工具卡 hover 頂線） ---- */
+    --color-brand-a: #667eea;
+    --color-brand-b: #764ba2;
+    --gradient-brand: linear-gradient(135deg, var(--color-brand-a) 0%, var(--color-brand-b) 100%);
+
+    /* ---- 主色（互動色：按鈕、連結、啟用中的篩選、焦點環） ---- */
+    --color-primary: #5061d3;
+    --color-primary-hover: #4352c6;
+    --color-primary-active: #3b49ba;
+    --color-primary-tint: #eeeffb;
+    --color-on-primary: #ffffff;
+    --ring-primary: 0 0 0 3px rgba(80, 97, 211, 0.3);
+    --glow-primary: 0 0 12px rgba(80, 97, 211, 0.55);
+    --glow-primary-strong: 0 0 22px rgba(80, 97, 211, 0.9);
+
+    /* ---- 中性色 ---- */
+    --color-bg: #f5f7fa;
+    --color-surface: #ffffff;
+    --color-surface-2: #f8f9fa;
+    --color-border: #e9ecef;
+    --color-border-strong: #ced4da;
+    --color-heading: #2c3e50;
+    --color-text: #333333;
+    --color-muted: #64707d;
+    --color-on-muted: #ffffff;
+    --color-hover: rgba(0, 0, 0, 0.05);
+    --color-mark: #fdf1de;
+    --color-overlay: rgba(0, 0, 0, 0.5);
+
+    /* ---- 語意色：fill / tint（柔和底）/ text（柔和底上的字）/ border / on（實心底上的字） ---- */
+    --color-success: #198754;
+    --color-success-tint: #e3f1ea;
+    --color-success-text: #146c43;
+    --color-success-border: #aed5c3;
+    --color-on-success: #ffffff;
+
+    --color-warning: #f39c12;
+    --color-warning-tint: #fdf1de;
+    --color-warning-text: #8a5a00;
+    --color-warning-border: #fbdcac;
+    --color-on-warning: #2c3e50;
+
+    --color-danger: #dc3545;
+    --color-danger-tint: #fcebec;
+    --color-danger-text: #a52834;
+    --color-danger-border: #f3b8be;
+    --color-on-danger: #ffffff;
+    --ring-danger: 0 0 0 3px rgba(220, 53, 69, 0.25);
+
+    --color-info: #0e7c9c;
+    --color-info-tint: #e7f2f5;
+    --color-info-text: #0b5e77;
+    --color-info-border: #abd1dc;
+    --color-on-info: #ffffff;
+
+    /* ---- 頁首、hero、頁尾 ---- */
+    --header-bg: var(--gradient-brand);
+    --header-text: #ffffff;
+    --nav-hover: rgba(255, 255, 255, 0.2);
+    --nav-active: rgba(255, 255, 255, 0.3);
+    --lang-bg: rgba(255, 255, 255, 0.12);
+    --lang-text: rgba(255, 255, 255, 0.85);
+    --lang-active-bg: rgba(255, 255, 255, 0.95);
+    --lang-active-text: #2c3e50;
+    --hero-bg: var(--gradient-brand);
+    --hero-text: #ffffff;
+    --hero-shadow: 0 10px 30px rgba(102, 126, 234, 0.3);
+    --footer-bg: #2c3e50;
+    --footer-text: rgba(255, 255, 255, 0.85);
+
+    /* ---- 陰影（帶標題色的透明度，不用純黑） ---- */
+    --shadow-sm: 0 1px 2px rgba(44, 62, 80, 0.06);
+    --shadow-md: 0 2px 8px rgba(44, 62, 80, 0.08);
+    --shadow-lg: 0 8px 24px rgba(44, 62, 80, 0.12);
+    --shadow-xl: 0 16px 40px rgba(44, 62, 80, 0.16);
+
+    /* ---- 圓角 ---- */
+    --radius-sm: 4px;
+    --radius-md: 6px;
+    --radius-lg: 12px;
+    --radius-xl: 16px;
+    --radius-full: 999px;
+
+    /* ---- 間距（4px 基底） ---- */
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-5: 20px;
+    --space-6: 24px;
+    --space-7: 32px;
+    --space-8: 40px;
+    --space-9: 48px;
+    --space-10: 64px;
+
+    /* ---- 字體 ---- */
+    --font-sans: 'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --text-xs: 0.75rem;
+    --text-sm: 0.875rem;
+    --text-md: 1rem;
+    --text-lg: 1.125rem;
+    --text-xl: 1.25rem;
+    --text-2xl: 1.5rem;
+    --text-3xl: 1.875rem;
+    --text-4xl: 2.25rem;
+    --text-5xl: 3rem;
+    --leading-tight: 1.2;
+    --leading-snug: 1.35;
+    --leading-normal: 1.6;
+    --leading-relaxed: 1.8;
+    --weight-normal: 400;
+    --weight-medium: 500;
+    --weight-semibold: 600;
+    --weight-bold: 700;
+
+    /* ---- 控制項高度 ---- */
+    --control-sm: 32px;
+    --control-md: 40px;
+    --control-lg: 48px;
+
+    /* ---- 動態 ---- */
+    --duration-fast: 150ms;
+    --duration-base: 200ms;
+    --duration-slow: 300ms;
+    --ease: cubic-bezier(0.4, 0, 0.2, 1);
+
+    /* ---- 版面 ---- */
+    --container-max: 1200px;
+    --container-narrow: 800px;
+    --container-gutter: 20px;
+    --z-header: 100;
+    --z-overlay: 1000;
+    --z-modal: 1001;
+    --z-toast: 9999;
+}
+
+[data-theme="dark"] {
+    --color-brand-a: #667eea;
+    --color-brand-b: #764ba2;
+    --gradient-brand: linear-gradient(135deg, #4b5ca8 0%, #563b79 100%);
+
+    --color-primary: #8b9cf5;
+    --color-primary-hover: #a0aef8;
+    --color-primary-active: #7c8cf0;
+    --color-primary-tint: #2c314e;
+    --color-on-primary: #0f1419;
+    --ring-primary: 0 0 0 3px rgba(139, 156, 245, 0.35);
+    --glow-primary: 0 0 12px rgba(139, 156, 245, 0.55);
+    --glow-primary-strong: 0 0 22px rgba(139, 156, 245, 0.9);
+
+    --color-bg: #0f1419;
+    --color-surface: #1a1d2e;
+    --color-surface-2: #2d3142;
+    --color-border: #3d4154;
+    --color-border-strong: #4d5270;
+    --color-heading: #f3f4f8;
+    --color-text: #e8e8e8;
+    --color-muted: #a0a8b8;
+    --color-on-muted: #0f1419;
+    --color-hover: rgba(255, 255, 255, 0.06);
+    --color-mark: rgba(247, 184, 74, 0.25);
+    --color-overlay: rgba(0, 0, 0, 0.7);
+
+    --color-success: #34d058;
+    --color-success-tint: rgba(52, 208, 88, 0.14);
+    --color-success-text: #6fe28f;
+    --color-success-border: rgba(52, 208, 88, 0.35);
+    --color-on-success: #0f1419;
+
+    --color-warning: #f7b84a;
+    --color-warning-tint: rgba(247, 184, 74, 0.14);
+    --color-warning-text: #f9c86e;
+    --color-warning-border: rgba(247, 184, 74, 0.35);
+    --color-on-warning: #0f1419;
+
+    --color-danger: #ff7b7b;
+    --color-danger-tint: rgba(255, 123, 123, 0.14);
+    --color-danger-text: #ff9c9c;
+    --color-danger-border: rgba(255, 123, 123, 0.35);
+    --color-on-danger: #0f1419;
+    --ring-danger: 0 0 0 3px rgba(255, 123, 123, 0.3);
+
+    --color-info: #20c9e6;
+    --color-info-tint: rgba(32, 201, 230, 0.14);
+    --color-info-text: #63d9ee;
+    --color-info-border: rgba(32, 201, 230, 0.35);
+    --color-on-info: #0f1419;
+
+    --header-text: #ffffff;
+    --nav-hover: rgba(255, 255, 255, 0.12);
+    --nav-active: rgba(255, 255, 255, 0.2);
+    --lang-bg: rgba(255, 255, 255, 0.08);
+    --lang-text: rgba(255, 255, 255, 0.75);
+    --lang-active-bg: rgba(255, 255, 255, 0.9);
+    --lang-active-text: #1a1d2e;
+    --hero-text: #ffffff;
+    --hero-shadow: 0 10px 30px rgba(102, 126, 234, 0.25);
+    --footer-bg: #1a1d2e;
+    --footer-text: rgba(255, 255, 255, 0.75);
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.4);
+    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
+    --shadow-xl: 0 16px 40px rgba(0, 0, 0, 0.6);
+}

--- a/assets/css/tools-common.css
+++ b/assets/css/tools-common.css
@@ -1,32 +1,35 @@
-/* ===================================
-   工具共用樣式 (Common Tool Styles)
-   =================================== */
-
-/* 引入元件樣式 */
+/* ==========================================================================
+   工具頁共用樣式 — 載入狀態、訊息、toast
+   元件本體由 components/*.css 提供（在此彙整載入）
+   ========================================================================== */
 @import url('components/buttons.css');
 @import url('components/cards.css');
 @import url('components/forms.css');
 @import url('components/tags.css');
 
-/* 工具頁面基礎樣式 */
+/* 工具頁基礎 */
 .tool-content {
-    padding: var(--spacing-xl, 2rem) 0;
+    padding: var(--space-7) 0;
 }
 
 /* 載入狀態 */
 .loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-3);
+    padding: var(--space-9) var(--space-4);
+    color: var(--color-muted);
     text-align: center;
-    padding: 3rem;
-    color: var(--text-secondary, #6c757d);
 }
 
 .loading-spinner {
-    display: inline-block;
-    width: 2rem;
-    height: 2rem;
-    border: 3px solid var(--gray-200, #e9ecef);
-    border-top-color: var(--primary-color, #4a90e2);
-    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+    border: 3px solid var(--color-border);
+    border-top-color: var(--color-primary);
+    border-radius: var(--radius-full);
     animation: spin 0.8s linear infinite;
 }
 
@@ -34,74 +37,104 @@
     to { transform: rotate(360deg); }
 }
 
-/* 錯誤訊息 */
-.error-message {
-    background-color: var(--danger-light, #f8d7da);
-    color: var(--danger-dark, #721c24);
-    padding: 1rem;
-    border-radius: 6px;
-    margin: 1rem 0;
-    border: 1px solid var(--danger-border, #f5c6cb);
-}
-
-/* 成功訊息 */
-.success-message {
-    background-color: var(--success-light, #d4edda);
-    color: var(--success-dark, #155724);
-    padding: 1rem;
-    border-radius: 6px;
-    margin: 1rem 0;
-    border: 1px solid var(--success-border, #c3e6cb);
-}
-
-/* 資訊訊息 */
-.info-message {
-    background-color: var(--info-light, #d1ecf1);
-    color: var(--info-dark, #0c5460);
-    padding: 1rem;
-    border-radius: 6px;
-    margin: 1rem 0;
-    border: 1px solid var(--info-border, #bee5eb);
-}
-
-/* 警告訊息 */
+/* 訊息（四種語意，同一形狀） */
+.error-message,
+.success-message,
+.info-message,
 .warning-message {
-    background-color: var(--warning-light, #fff3cd);
-    color: var(--warning-dark, #856404);
-    padding: 1rem;
-    border-radius: 6px;
-    margin: 1rem 0;
-    border: 1px solid var(--warning-border, #ffeaa7);
+    padding: var(--space-3) var(--space-4);
+    margin: var(--space-4) 0;
+    border: 1px solid;
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    line-height: 1.5;
 }
 
-/* Toast 通知訊息 */
+.error-message {
+    background: var(--color-danger-tint);
+    border-color: var(--color-danger-border);
+    color: var(--color-danger-text);
+}
+
+.success-message {
+    background: var(--color-success-tint);
+    border-color: var(--color-success-border);
+    color: var(--color-success-text);
+}
+
+.info-message {
+    background: var(--color-info-tint);
+    border-color: var(--color-info-border);
+    color: var(--color-info-text);
+}
+
+.warning-message {
+    background: var(--color-warning-tint);
+    border-color: var(--color-warning-border);
+    color: var(--color-warning-text);
+}
+
+.message-title {
+    display: block;
+    font-weight: var(--weight-semibold);
+}
+
+/* Toast 通知（右上角，3 秒後由 JS 移除） */
 .toast {
     position: fixed;
-    top: 20px;
-    right: 20px;
-    padding: 12px 24px;
-    border-radius: 6px;
-    color: white;
-    font-weight: 500;
-    z-index: 9999;
+    top: var(--space-5);
+    right: var(--space-5);
+    z-index: var(--z-toast);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    max-width: min(360px, calc(100vw - var(--space-8)));
+    padding: 10px 18px;
+    border-radius: var(--radius-md);
+    background: var(--color-heading);
+    color: var(--color-surface);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    line-height: 1.4;
+    box-shadow: var(--shadow-lg);
     opacity: 0;
     transform: translateY(-20px);
-    transition: all 0.3s ease;
+    transition: opacity var(--duration-slow) var(--ease), transform var(--duration-slow) var(--ease);
     white-space: pre-line;
+    pointer-events: none;
+}
+
+.toast.show {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .toast-success {
-    background-color: #27ae60;
+    background: var(--color-success);
+    color: var(--color-on-success);
 }
 
 .toast-error {
-    background-color: #e74c3c;
+    background: var(--color-danger);
+    color: var(--color-on-danger);
 }
 
 .toast-warning {
-    background-color: #f39c12;
+    background: var(--color-warning);
+    color: var(--color-on-warning);
 }
 
 .toast-info {
-    background-color: #3498db;
+    background: var(--color-info);
+    color: var(--color-on-info);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .loading-spinner {
+        animation-duration: 1.6s;
+    }
+
+    .toast {
+        transition: none;
+    }
 }

--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,27 @@
                 <p class="subtitle" data-i18n="changelog_hero_subtitle">記錄 FF14.tw 的功能更新與改進</p>
 
                 <div class="changelog-container">
+                <!-- 2026年8月 -->
+                <section class="changelog-section">
+                    <h2 class="changelog-year">2026年8月</h2>
+
+                    <article class="changelog-entry">
+                        <div class="changelog-header">
+                            <h3 class="changelog-version">v2.13.0</h3>
+                            <time class="changelog-date" datetime="2026-08-26">2026年8月26日</time>
+                        </div>
+                        <div class="changelog-content">
+                            <ul>
+                                <li><span class="tag tag-success">新增</span> 設計系統：全站顏色、字級、圓角、陰影改由同一份 token 定義，深色模式一併統一</li>
+                                <li><span class="tag tag-info">改善</span> 按鈕、表單、標籤、卡片、訊息改用統一元件；主色改為對比度合格的靛藍，次要按鈕不再顯示為橘色</li>
+                                <li><span class="tag tag-info">改善</span> 每一頁統一載入 Noto Sans TC 字型</li>
+                                <li><span class="tag tag-info">改善</span> 巨集轉換器、檢舉模板產生器、攻略資料改用設計系統</li>
+                                <li><span class="tag tag-warning">修正</span> 副本資料庫深色模式下標題與底色同色而看不見、巨集轉換器面板沒有底色、特殊採集時間管理器搜尋框左側留白</li>
+                            </ul>
+                        </div>
+                    </article>
+                </section>
+
                 <!-- 2026年3月 -->
                 <section class="changelog-section">
                     <h2 class="changelog-year">2026年3月</h2>

--- a/changelog.html
+++ b/changelog.html
@@ -6,6 +6,10 @@
     <title>修改紀錄 - FF14.tw</title>
     <meta name="description" content="FF14.tw 網站功能更新與修改紀錄">
     <link rel="icon" type="image/x-icon" href="assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/tokens.css">
     <link rel="stylesheet" href="assets/css/common.css">
     <link rel="stylesheet" href="assets/css/changelog.css">
     <link rel="stylesheet" href="assets/css/components/language-switcher.css">

--- a/copyright.html
+++ b/copyright.html
@@ -6,11 +6,12 @@
     <title>版權聲明 - FF14.tw</title>
     <meta name="description" content="FF14.tw 版權聲明與使用條款">
     <link rel="icon" type="image/x-icon" href="assets/images/ff14tw.ico">
-    <link rel="stylesheet" href="assets/css/common.css">
-    <link rel="stylesheet" href="assets/css/components/language-switcher.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/tokens.css">
+    <link rel="stylesheet" href="assets/css/common.css">
+    <link rel="stylesheet" href="assets/css/components/language-switcher.css">
     <style>
         .copyright-content {
             max-width: 800px;

--- a/index.html
+++ b/index.html
@@ -6,11 +6,12 @@
     <title>FF14.tw - Final Fantasy XIV工具箱</title>
     <meta name="description" content="FF14.tw 提供各種Final Fantasy XIV相關的實用工具，包含角色卡產生器、宗長計算機等。">
     <link rel="icon" type="image/x-icon" href="assets/images/ff14tw.ico">
-    <link rel="stylesheet" href="assets/css/common.css">
-    <link rel="stylesheet" href="assets/css/components/language-switcher.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/tokens.css">
+    <link rel="stylesheet" href="assets/css/common.css">
+    <link rel="stylesheet" href="assets/css/components/language-switcher.css">
     <style>
         /* 首頁專用樣式 - 簡潔工具展示 */
         .hero {

--- a/scripts/add-design-links.mjs
+++ b/scripts/add-design-links.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * 為每一個頁面補上 tokens.css 與 Google Fonts 連結，並把字重統一為 400/500/600/700。
+ * 可重複執行：已符合的頁面不會被改動。
+ * 用法：node scripts/add-design-links.mjs
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SKIP_DIRS = new Set(['api', 'node_modules', 'docs', '.git', '.claude', '.superpowers']);
+const FONT_HREF = 'https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap';
+
+function listPages(dir = ROOT, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) listPages(full, out);
+        else if (entry.name.endsWith('.html')) out.push(full);
+    }
+    return out;
+}
+
+const FONT_HOSTS = new Set(['fonts.googleapis.com', 'fonts.gstatic.com']);
+
+// 只認 <link>，且 href 的主機名稱要完全等於 Google Fonts 的網域（不是子字串比對）
+function isFontLink(line) {
+    if (!/<link\b/i.test(line)) return false;
+    const match = line.match(/href="([^"]+)"/);
+    if (!match) return false;
+    try {
+        return FONT_HOSTS.has(new URL(match[1]).hostname);
+    } catch {
+        return false;
+    }
+}
+
+function isTokensLink(line) {
+    return /<link\b/i.test(line) && /href="[^"]*assets\/css\/tokens\.css"/.test(line);
+}
+
+let changed = 0;
+for (const page of listPages()) {
+    const original = fs.readFileSync(page, 'utf8');
+    const lines = original.split('\n');
+
+    // 1. 找到 common.css 那一行，記下縮排與相對路徑前綴（'' 或 '../../'）
+    const commonIndex = lines.findIndex((line) => /<link[^>]+href="[^"]*assets\/css\/common\.css"/.test(line));
+    if (commonIndex === -1) {
+        console.error(`略過（找不到 common.css）：${path.relative(ROOT, page)}`);
+        continue;
+    }
+    const indent = lines[commonIndex].match(/^\s*/)[0];
+    const prefix = lines[commonIndex].match(/href="([^"]*)assets\/css\/common\.css"/)[1];
+
+    // 2. 移除舊的字型與 tokens 連結（之後統一重插）
+    const kept = lines.filter((line) => !(isFontLink(line) || isTokensLink(line)));
+
+    // 3. 在 common.css 前插入：preconnect ×2、字型、tokens.css
+    const insertAt = kept.findIndex((line) => /<link[^>]+href="[^"]*assets\/css\/common\.css"/.test(line));
+    const block = [
+        `${indent}<link rel="preconnect" href="https://fonts.googleapis.com">`,
+        `${indent}<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>`,
+        `${indent}<link href="${FONT_HREF}" rel="stylesheet">`,
+        `${indent}<link rel="stylesheet" href="${prefix}assets/css/tokens.css">`,
+    ];
+    kept.splice(insertAt, 0, ...block);
+
+    const next = kept.join('\n');
+    if (next !== original) {
+        fs.writeFileSync(page, next);
+        changed++;
+        console.log(`已更新：${path.relative(ROOT, page)}`);
+    }
+}
+console.log(`完成，共更新 ${changed} 頁`);

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -13,6 +13,7 @@ const TOKEN_CLEAN_FILES = [
     'assets/css/components/language-switcher.css',
     'assets/css/components/buttons.css',
     'assets/css/components/forms.css',
+    'assets/css/components/tags.css',
 ];
 
 // ---------- 小工具 ----------

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -9,6 +9,8 @@ const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
 // 已完成遷移、必須「只讀 token」的檔案；每個任務完成後把檔案加進來
 const TOKEN_CLEAN_FILES = [
     'assets/css/tokens.css',
+    'assets/css/common.css',
+    'assets/css/components/language-switcher.css',
 ];
 
 // ---------- 小工具 ----------

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -1,0 +1,103 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+// 已完成遷移、必須「只讀 token」的檔案；每個任務完成後把檔案加進來
+const TOKEN_CLEAN_FILES = [
+    'assets/css/tokens.css',
+];
+
+// ---------- 小工具 ----------
+function stripComments(css) {
+    return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+function block(css, selector) {
+    // 取出 `selector {` … `}` 的內容（token 檔只有一層大括號）
+    const start = css.indexOf(selector + ' {');
+    assert.notEqual(start, -1, `找不到區塊 ${selector}`);
+    const end = css.indexOf('}', start);
+    return css.slice(start + selector.length + 2, end);
+}
+function definitions(cssBlock) {
+    const map = new Map();
+    for (const m of cssBlock.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) map.set(m[1], m[2].trim());
+    return map;
+}
+function usedVars(css) {
+    return [...css.matchAll(/var\(\s*(--[a-z0-9-]+)/g)].map((m) => m[1]);
+}
+function hasColorLiteral(value) {
+    return /#[0-9a-f]{3,8}\b|rgba?\(|hsla?\(/i.test(value);
+}
+function hex2rgb(hex) {
+    const h = hex.replace('#', '');
+    return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+}
+function luminance(hex) {
+    const lin = (c) => { c /= 255; return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4; };
+    const [r, g, b] = hex2rgb(hex);
+    return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+function contrast(a, b) {
+    const la = luminance(a), lb = luminance(b);
+    const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+    return (hi + 0.05) / (lo + 0.05);
+}
+
+const tokensCss = stripComments(read('assets/css/tokens.css'));
+const light = definitions(block(tokensCss, ':root'));
+const dark = definitions(block(tokensCss, '[data-theme="dark"]'));
+
+// ---------- 測試 ----------
+test('深色模式重新指定每一個含色碼的 token，且沒有只在深色出現的 token', () => {
+    for (const [name, value] of light) {
+        if (hasColorLiteral(value)) assert.ok(dark.has(name), `${name} 在 [data-theme="dark"] 缺少定義`);
+    }
+    for (const name of dark.keys()) assert.ok(light.has(name), `${name} 只在深色定義，:root 沒有`);
+});
+
+test('關鍵配色對比度達 WCAG AA（4.5:1）', () => {
+    const pairs = [
+        ['--color-on-primary', '--color-primary'],
+        ['--color-text', '--color-bg'],
+        ['--color-heading', '--color-surface'],
+        ['--color-muted', '--color-bg'],
+        ['--color-muted', '--color-surface'],
+        ['--color-on-success', '--color-success'],
+        ['--color-on-warning', '--color-warning'],
+        ['--color-on-danger', '--color-danger'],
+        ['--color-on-info', '--color-info'],
+        ['--color-primary', '--color-surface'],
+    ];
+    for (const theme of [light, dark]) {
+        for (const [fg, bg] of pairs) {
+            const f = theme.get(fg), b = theme.get(bg);
+            assert.match(f, /^#[0-9a-f]{6}$/i, `${fg} 必須是 6 位色碼`);
+            assert.match(b, /^#[0-9a-f]{6}$/i, `${bg} 必須是 6 位色碼`);
+            const ratio = contrast(f, b);
+            assert.ok(ratio >= 4.5, `${fg} 對 ${bg} 對比 ${ratio.toFixed(2)} < 4.5`);
+        }
+    }
+});
+
+test('token-clean 檔案只讀 tokens.css、沒有色碼、沒有 @import、沒有 !important', () => {
+    const allowed = new Set(light.keys());
+    for (const file of TOKEN_CLEAN_FILES) {
+        const css = stripComments(read(file));
+        const own = new Set(definitions(css).keys());
+        for (const name of usedVars(css)) {
+            assert.ok(allowed.has(name) || own.has(name), `${file} 引用了未定義的 ${name}`);
+        }
+        if (file !== 'assets/css/tokens.css') {
+            const noUrls = css.replace(/url\([^)]*\)/g, 'url()');
+            const literal = noUrls.match(/#[0-9a-f]{3,8}\b|rgba?\(|hsla?\(|(?<![\w-])(white|black)(?![\w-])/i);
+            assert.equal(literal, null, `${file} 含有色碼：${literal && literal[0]}`);
+            assert.doesNotMatch(css, /@import/, `${file} 不得使用 @import`);
+            assert.doesNotMatch(css, /!important/, `${file} 不得使用 !important`);
+        }
+    }
+});

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -17,6 +17,7 @@ const TOKEN_CLEAN_FILES = [
     'assets/css/components/cards.css',
     'assets/css/tools-common.css',
     'tools/macro-converter/style.css',
+    'tools/report-generator/style.css',
 ];
 
 // 這個檔案的職責就是彙整元件，允許 @import components/*.css

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -12,6 +12,7 @@ const TOKEN_CLEAN_FILES = [
     'assets/css/common.css',
     'assets/css/components/language-switcher.css',
     'assets/css/components/buttons.css',
+    'assets/css/components/forms.css',
 ];
 
 // ---------- 小工具 ----------

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -14,6 +14,7 @@ const TOKEN_CLEAN_FILES = [
     'assets/css/components/buttons.css',
     'assets/css/components/forms.css',
     'assets/css/components/tags.css',
+    'assets/css/components/cards.css',
 ];
 
 // ---------- 小工具 ----------

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -11,6 +11,7 @@ const TOKEN_CLEAN_FILES = [
     'assets/css/tokens.css',
     'assets/css/common.css',
     'assets/css/components/language-switcher.css',
+    'assets/css/components/buttons.css',
 ];
 
 // ---------- 小工具 ----------

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -16,6 +16,7 @@ const TOKEN_CLEAN_FILES = [
     'assets/css/components/tags.css',
     'assets/css/components/cards.css',
     'assets/css/tools-common.css',
+    'tools/macro-converter/style.css',
 ];
 
 // 這個檔案的職責就是彙整元件，允許 @import components/*.css

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -15,7 +15,14 @@ const TOKEN_CLEAN_FILES = [
     'assets/css/components/forms.css',
     'assets/css/components/tags.css',
     'assets/css/components/cards.css',
+    'assets/css/tools-common.css',
 ];
+
+// 這個檔案的職責就是彙整元件，允許 @import components/*.css
+const IMPORT_ALLOWED = new Set(['assets/css/tools-common.css']);
+
+// 元件與已遷移的工具不得自帶 dark 規則；只有 tokens.css（定義）與 common.css（.hero 過渡覆寫）例外
+const DARK_RULES_ALLOWED = new Set(['assets/css/tokens.css', 'assets/css/common.css']);
 
 // ---------- 小工具 ----------
 function stripComments(css) {
@@ -102,7 +109,8 @@ test('token-clean 檔案只讀 tokens.css、沒有色碼、沒有 @import、沒�
             const noUrls = css.replace(/url\([^)]*\)/g, 'url()');
             const literal = noUrls.match(/#[0-9a-f]{3,8}\b|rgba?\(|hsla?\(|(?<![\w-])(white|black)(?![\w-])/i);
             assert.equal(literal, null, `${file} 含有色碼：${literal && literal[0]}`);
-            assert.doesNotMatch(css, /@import/, `${file} 不得使用 @import`);
+            if (!IMPORT_ALLOWED.has(file)) assert.doesNotMatch(css, /@import/, `${file} 不得使用 @import`);
+            if (!DARK_RULES_ALLOWED.has(file)) assert.doesNotMatch(css, /\[data-theme=/, `${file} 不得自帶 [data-theme] 規則`);
             assert.doesNotMatch(css, /!important/, `${file} 不得使用 !important`);
         }
     }

--- a/tests/design-system.test.js
+++ b/tests/design-system.test.js
@@ -18,6 +18,7 @@ const TOKEN_CLEAN_FILES = [
     'assets/css/tools-common.css',
     'tools/macro-converter/style.css',
     'tools/report-generator/style.css',
+    'tools/guide/style.css',
 ];
 
 // 這個檔案的職責就是彙整元件，允許 @import components/*.css

--- a/tests/pages.test.js
+++ b/tests/pages.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const SKIP_DIRS = new Set(['api', 'node_modules', 'docs', '.git', '.claude', '.superpowers']);
+const FONT_HREF = 'https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap';
+
+function listPages(dir = ROOT, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) listPages(full, out);
+        else if (entry.name.endsWith('.html')) out.push(full);
+    }
+    return out;
+}
+
+function listToolCss(out = []) {
+    const toolsDir = path.join(ROOT, 'tools');
+    for (const tool of fs.readdirSync(toolsDir)) {
+        const dir = path.join(toolsDir, tool);
+        if (!fs.statSync(dir).isDirectory()) continue;
+        for (const file of fs.readdirSync(dir)) {
+            if (file.endsWith('.css')) out.push(path.join(dir, file));
+        }
+    }
+    return out;
+}
+
+const rel = (p) => path.relative(ROOT, p);
+const pages = listPages();
+
+test('頁面清單不是空的（至少 20 頁）', () => {
+    assert.ok(pages.length >= 20, `只找到 ${pages.length} 頁`);
+});
+
+test('每一頁都載入 tokens.css，且在 common.css 之前', () => {
+    for (const page of pages) {
+        const html = fs.readFileSync(page, 'utf8');
+        const tokensAt = html.indexOf('assets/css/tokens.css');
+        const commonAt = html.indexOf('assets/css/common.css');
+        assert.notEqual(commonAt, -1, `${rel(page)} 沒有載入 common.css`);
+        assert.notEqual(tokensAt, -1, `${rel(page)} 沒有載入 tokens.css`);
+        assert.ok(tokensAt < commonAt, `${rel(page)} 的 tokens.css 必須排在 common.css 之前`);
+    }
+});
+
+test('每一頁都用同一個 Google Fonts 連結（Noto Sans TC 400/500/600/700）', () => {
+    for (const page of pages) {
+        const html = fs.readFileSync(page, 'utf8');
+        assert.ok(html.includes(FONT_HREF), `${rel(page)} 缺少標準字型連結`);
+        assert.ok(!html.includes('wght@300'), `${rel(page)} 仍載入字重 300`);
+        assert.ok(html.includes('href="https://fonts.gstatic.com" crossorigin'), `${rel(page)} 缺少 fonts.gstatic.com preconnect`);
+    }
+});
+
+test('工具 CSS 不得以 @import 重複載入 /assets/css 的共用樣式', () => {
+    for (const file of listToolCss()) {
+        const css = fs.readFileSync(file, 'utf8');
+        assert.doesNotMatch(css, /@import\s+url\(\s*['"]?\/?assets\/css\//, `${rel(file)} 以 @import 重複載入共用樣式`);
+    }
+});

--- a/tools/character-card/index.html
+++ b/tools/character-card/index.html
@@ -6,14 +6,15 @@
     <title>角色卡產生器 - FF14.tw</title>
     <meta name="description" content="快速生成你的FF14角色資訊卡片，支援多種樣式和自訂選項。">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <div id="header-placeholder" data-base-path="../../" data-tool-name="角色卡產生器" data-tool-name-key="char_card_header"></div>

--- a/tools/character-card/style.css
+++ b/tools/character-card/style.css
@@ -1,6 +1,5 @@
 /* Optimized font loading - only weights actually used in design */
 @import url('https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@600&family=DM+Sans:wght@400;500;600;700&family=Cinzel:wght@600;900&display=swap');
-@import url('/assets/css/tools-common.css');
 
 /*
  * Character Card Generator - Luxury Editorial Design

--- a/tools/dungeon-database/index.html
+++ b/tools/dungeon-database/index.html
@@ -6,14 +6,15 @@
     <title>副本資料庫 - FF14.tw</title>
     <meta name="description" content="FF14副本完整資料庫，包含所有副本資訊、獎勵和攻略指南。">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <div id="header-placeholder" data-base-path="../../" data-tool-name="副本資料庫" data-tool-name-key="dungeon_db_header"></div>

--- a/tools/dungeon-database/style.css
+++ b/tools/dungeon-database/style.css
@@ -1,4 +1,3 @@
-@import url('/assets/css/tools-common.css');
 
 /* 副本資料庫樣式 */
 

--- a/tools/faux-hollows-foxes/index.html
+++ b/tools/faux-hollows-foxes/index.html
@@ -6,6 +6,10 @@
     <title>Faux Hollows Foxes 計算機 - FF14.tw</title>
     <meta name="description" content="計算 FF14 Faux Hollows Foxes 活動的最佳點擊策略">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">

--- a/tools/faux-hollows-foxes/style.css
+++ b/tools/faux-hollows-foxes/style.css
@@ -1,4 +1,3 @@
-@import url('/assets/css/tools-common.css');
 
 /* Faux Hollows Foxes Calculator Styles */
 

--- a/tools/guide/aether.html
+++ b/tools/guide/aether.html
@@ -8,16 +8,16 @@
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
 
     <!-- Required CSS imports -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Header placeholder -->

--- a/tools/guide/chocobo.html
+++ b/tools/guide/chocobo.html
@@ -8,16 +8,16 @@
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
 
     <!-- Required CSS imports -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Header placeholder -->

--- a/tools/guide/dungeon.html
+++ b/tools/guide/dungeon.html
@@ -8,16 +8,16 @@
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
 
     <!-- Required CSS imports -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Header placeholder -->

--- a/tools/guide/grand-company.html
+++ b/tools/guide/grand-company.html
@@ -8,16 +8,16 @@
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
 
     <!-- Required CSS imports -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Header placeholder -->

--- a/tools/guide/guild.html
+++ b/tools/guide/guild.html
@@ -8,16 +8,16 @@
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
 
     <!-- Required CSS imports -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Header placeholder -->

--- a/tools/guide/index.html
+++ b/tools/guide/index.html
@@ -8,16 +8,16 @@
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
 
     <!-- Required CSS imports -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Header placeholder -->

--- a/tools/guide/party.html
+++ b/tools/guide/party.html
@@ -8,16 +8,16 @@
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
 
     <!-- Required CSS imports -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Header placeholder -->

--- a/tools/guide/sightseeing.html
+++ b/tools/guide/sightseeing.html
@@ -8,16 +8,16 @@
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
 
     <!-- Required CSS imports -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Header placeholder -->

--- a/tools/guide/style.css
+++ b/tools/guide/style.css
@@ -1,98 +1,75 @@
-/* Guide Tool Styles */
-
 /* ==========================================================================
-   Landing Page
+   攻略資料 — 只寫版面；顏色、圓角、字級一律來自 tokens.css 與共用元件
    ========================================================================== */
 
+/* ---- 主題選單（index.html） ---- */
 .guide-landing {
     text-align: center;
-    padding: 3rem 0;
+    padding: var(--space-9) 0;
 }
 
 .landing-title {
-    font-size: 2.5rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin: 0 0 1rem 0;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-4xl);
+    font-weight: var(--weight-bold);
+    line-height: var(--leading-tight);
+    color: var(--color-heading);
 }
 
 .landing-subtitle {
-    font-size: 1.2rem;
-    color: var(--text-secondary, #666);
-    margin: 0 0 3rem 0;
+    margin: 0 0 var(--space-9);
+    font-size: var(--text-lg);
+    color: var(--color-muted);
 }
 
 .guide-cards-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 2rem;
+    gap: var(--space-7);
     max-width: 1000px;
     margin: 0 auto;
 }
 
 .guide-card {
-    background: var(--card-bg, white);
-    border-radius: var(--border-radius-lg, 12px);
-    padding: 2rem;
+    display: block;
+    padding: var(--space-7);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
     text-decoration: none;
     color: inherit;
-    box-shadow: var(--shadow);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-    border: 2px solid transparent;
+    transition: transform var(--duration-slow) var(--ease), box-shadow var(--duration-slow) var(--ease), border-color var(--duration-slow) var(--ease);
 }
 
 .guide-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
-    border-color: var(--primary-color);
-}
-
-.guide-card-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--color-primary);
+    color: inherit;
 }
 
 .guide-card-title {
-    font-size: 1.4rem;
-    font-weight: 600;
-    color: var(--dark-color, #333);
-    margin: 0 0 0.75rem 0;
+    margin: 0 0 var(--space-3);
+    font-size: var(--text-xl);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
 }
 
 .guide-card-desc {
-    font-size: 0.95rem;
-    color: var(--text-secondary, #666);
     margin: 0;
-    line-height: 1.6;
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    color: var(--color-muted);
 }
 
-/* Dark mode landing page */
-[data-theme="dark"] .guide-card {
-    background: var(--card-bg);
-}
-
-[data-theme="dark"] .guide-card:hover {
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
-}
-
-[data-theme="dark"] .guide-card-title {
-    color: var(--text-color);
-}
-
-[data-theme="dark"] .guide-card-desc {
-    color: var(--text-secondary);
-}
-
-/* ==========================================================================
-   Layout System
-   ========================================================================== */
-
+/* ---- 版面：目錄側欄 + 文章 ---- */
 .guide-layout {
     display: flex;
-    gap: 3rem;
+    gap: var(--space-8);
     align-items: flex-start;
     position: relative;
-    padding: 2rem 0;
+    padding: var(--space-7) 0;
 }
 
 .guide-content-wrapper {
@@ -101,289 +78,140 @@
     max-width: 900px;
 }
 
-/* ==========================================================================
-   Sticky TOC Sidebar
-   ========================================================================== */
-
+/* ---- 目錄側欄（sidebar-template.js 產生） ---- */
 .toc-sidebar {
     position: sticky;
-    top: 2rem;
-    width: 280px;
+    top: var(--space-7);
+    width: clamp(220px, 22vw, 280px);
     flex-shrink: 0;
-    max-height: calc(100vh - 4rem);
+    max-height: calc(100vh - var(--space-10));
     overflow-y: auto;
 }
 
 .toc-container {
-    background: var(--card-bg, white);
-    border-radius: var(--border-radius-lg, 12px);
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
+    padding: var(--space-6);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
 }
-
-/* ==========================================================================
-   Search Box
-   ========================================================================== */
-
-.guide-search {
-    margin-bottom: 1.5rem;
-}
-
-.guide-search .form-control {
-    font-size: 0.9rem;
-    padding: 0.6rem 1rem;
-    border-radius: var(--border-radius, 8px);
-}
-
-.guide-search .form-control:focus {
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.15);
-}
-
-.search-results-info {
-    display: none;
-    margin-top: 1rem;
-    padding: 0.5rem;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    text-align: center;
-    background: var(--gray-100, #f5f5f5);
-    border-radius: var(--border-radius-sm, 6px);
-}
-
-.search-results-info.visible {
-    display: block;
-}
-
-/* ==========================================================================
-   TOC Navigation
-   ========================================================================== */
 
 .toc-title {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--primary-color);
-    margin: 0 0 1rem 0;
-    padding-bottom: 0.5rem;
-    border-bottom: 2px solid var(--primary-color);
+    margin: 0 0 var(--space-4);
+    padding-bottom: var(--space-2);
+    font-size: var(--text-md);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
+    border-bottom: 2px solid var(--color-primary);
 }
 
 .toc-nav {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: var(--space-1);
 }
 
 .toc-link {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    color: var(--text-color);
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    color: var(--color-text);
     text-decoration: none;
-    padding: 0.6rem 0.75rem;
-    border-radius: var(--border-radius-sm, 6px);
-    transition: all 0.2s ease;
-    font-size: 0.95rem;
-    border-left: 3px solid transparent;
+    font-size: var(--text-sm);
+    transition: background-color var(--duration-base) var(--ease), color var(--duration-base) var(--ease);
 }
 
 .toc-link:hover {
-    background: var(--gray-100, #f5f5f5);
-    color: var(--primary-color);
+    background: var(--color-primary-tint);
+    color: var(--color-primary);
 }
 
 .toc-link.active {
-    background: var(--primary-color);
-    color: white;
-    border-left-color: transparent;
+    background: var(--color-primary);
+    color: var(--color-on-primary);
 }
 
 .toc-icon {
-    font-size: 1.1rem;
-    width: 1.5rem;
-    text-align: center;
+    width: 24px;
     flex-shrink: 0;
+    font-size: var(--text-md);
+    text-align: center;
 }
 
-/* Search match states for TOC */
-.toc-link.has-match {
-    background: rgba(74, 144, 226, 0.1);
-    border-left-color: var(--primary-color);
-}
-
-.toc-link.no-match {
-    opacity: 0.4;
-}
-
-/* Back to landing link */
 .back-to-landing {
     display: block;
-    margin-top: 1.5rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--border-color, #e0e0e0);
-    color: var(--text-secondary, #666);
+    margin-top: var(--space-6);
+    padding-top: var(--space-4);
+    border-top: 1px solid var(--color-border);
+    color: var(--color-muted);
     text-decoration: none;
-    font-size: 0.9rem;
-    transition: color 0.2s ease;
+    font-size: var(--text-sm);
+    transition: color var(--duration-base) var(--ease);
 }
 
 .back-to-landing:hover {
-    color: var(--primary-color);
+    color: var(--color-primary);
 }
 
-/* TOC Scrollbar */
 .toc-sidebar::-webkit-scrollbar {
     width: 6px;
 }
 
 .toc-sidebar::-webkit-scrollbar-track {
-    background: var(--gray-100, #f1f1f1);
-    border-radius: 3px;
+    background: var(--color-surface-2);
+    border-radius: var(--radius-sm);
 }
 
 .toc-sidebar::-webkit-scrollbar-thumb {
-    background: var(--gray-400, #888);
-    border-radius: 3px;
+    background: var(--color-border-strong);
+    border-radius: var(--radius-sm);
 }
 
 .toc-sidebar::-webkit-scrollbar-thumb:hover {
-    background: var(--gray-600, #555);
+    background: var(--color-muted);
 }
 
-/* ==========================================================================
-   Guide Sections
-   ========================================================================== */
-
-.guide-section {
-    background: var(--card-bg, white);
-    border-radius: var(--border-radius-lg, 12px);
-    padding: 2.5rem;
-    margin-bottom: 2rem;
-    box-shadow: var(--shadow);
-    scroll-margin-top: 2rem;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.guide-section:last-child {
-    margin-bottom: 0;
-}
-
-.guide-section:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-}
-
-/* Section Title */
-.section-title {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-size: 1.6rem;
-    font-weight: 600;
-    color: var(--primary-color);
-    margin: 0 0 1.5rem 0;
-    padding-bottom: 0.75rem;
-    border-bottom: 2px solid var(--border-color, #e0e0e0);
-}
-
-.section-icon {
-    font-size: 1.4rem;
-}
-
-/* Section Content - Optimized for reading */
-.section-content {
-    line-height: 1.8;
-    color: var(--text-color);
-}
-
-.section-content h3 {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--dark-color, #333);
-    margin: 2rem 0 1rem;
-}
-
-.section-content h3:first-child {
-    margin-top: 0;
-}
-
-.section-content h4 {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--text-color);
-    margin: 1.5rem 0 0.75rem;
-}
-
-.section-content p {
-    margin-bottom: 1.25rem;
-    text-align: justify;
-}
-
-.section-content ul,
-.section-content ol {
-    margin: 1rem 0;
-    padding-left: 1.5rem;
-}
-
-.section-content li {
-    margin-bottom: 0.5rem;
-}
-
-.section-content li strong {
-    color: var(--primary-color);
-}
-
-/* Search hidden state */
-.guide-section.search-hidden {
-    display: none;
-}
-
-/* Search highlight */
-.search-highlight {
-    background: linear-gradient(180deg, transparent 50%, rgba(74, 144, 226, 0.3) 50%);
-    padding: 0 2px;
-    border-radius: 2px;
-}
-
-/* ==========================================================================
-   Article Styles (Sub-pages)
-   ========================================================================== */
-
+/* ---- 文章 ---- */
 .guide-article {
-    background: var(--card-bg, white);
-    border-radius: var(--border-radius-lg, 12px);
-    padding: 2.5rem;
-    box-shadow: var(--shadow);
+    padding: var(--space-8);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
 }
 
 .article-title {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin: 0 0 2rem 0;
-    padding-bottom: 1rem;
-    border-bottom: 3px solid var(--primary-color);
+    gap: var(--space-3);
+    margin: 0 0 var(--space-7);
+    padding-bottom: var(--space-4);
+    font-size: var(--text-3xl);
+    font-weight: var(--weight-bold);
+    line-height: var(--leading-tight);
+    color: var(--color-heading);
+    border-bottom: 2px solid var(--color-primary);
 }
 
 .article-icon {
-    font-size: 1.8rem;
+    font-size: var(--text-3xl);
+    line-height: 1;
 }
 
 .article-content {
-    line-height: 1.8;
-    color: var(--text-color);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text);
 }
 
 .article-content h2 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--dark-color, #333);
-    margin: 2.5rem 0 1rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 2px solid var(--border-color, #e0e0e0);
+    margin: var(--space-8) 0 var(--space-4);
+    padding-bottom: var(--space-2);
+    font-size: var(--text-2xl);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
+    border-bottom: 1px solid var(--color-border);
 }
 
 .article-content h2:first-child {
@@ -391,42 +219,38 @@
 }
 
 .article-content h3 {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--dark-color, #333);
-    margin: 2rem 0 1rem;
+    margin: var(--space-7) 0 var(--space-3);
+    font-size: var(--text-xl);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
 }
 
 .article-content h4 {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--text-color);
-    margin: 1.5rem 0 0.75rem;
+    margin: var(--space-6) 0 var(--space-3);
+    font-size: var(--text-lg);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
 }
 
 .article-content p {
-    margin-bottom: 1.25rem;
-    text-align: justify;
+    margin-bottom: var(--space-5);
 }
 
 .article-content ul,
 .article-content ol {
-    margin: 1rem 0;
-    padding-left: 1.5rem;
+    margin: var(--space-4) 0;
+    padding-left: var(--space-6);
 }
 
 .article-content li {
-    margin-bottom: 0.5rem;
+    margin-bottom: var(--space-2);
 }
 
 .article-content li strong {
-    color: var(--primary-color);
+    color: var(--color-primary);
 }
 
-/* ==========================================================================
-   Coming Soon
-   ========================================================================== */
-
+/* ---- 尚未完成的主題 ---- */
 .coming-soon {
     display: flex;
     align-items: center;
@@ -436,63 +260,49 @@
 }
 
 .coming-soon p {
-    font-size: 1.25rem;
-    color: var(--text-secondary, #666);
     margin: 0;
-    padding: 2rem;
-    background: var(--gray-50, #f9fafb);
-    border-radius: var(--border-radius-lg, 12px);
-    border: 2px dashed var(--border-color, #e0e0e0);
+    padding: var(--space-7);
+    font-size: var(--text-lg);
+    color: var(--color-muted);
+    background: var(--color-surface-2);
+    border: 1px dashed var(--color-border-strong);
+    border-radius: var(--radius-lg);
 }
 
-[data-theme="dark"] .coming-soon p {
-    background: var(--bg-secondary, #252836);
-    border-color: var(--border-color);
-    color: var(--text-secondary);
-}
-
-/* Dark mode article */
-[data-theme="dark"] .guide-article {
-    background: var(--card-bg);
-}
-
-[data-theme="dark"] .article-content h2,
-[data-theme="dark"] .article-content h3 {
-    color: var(--text-color);
-}
-
-/* ==========================================================================
-   Page Navigation
-   ========================================================================== */
-
+/* ---- 上一篇 / 下一篇 ---- */
 .page-nav {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-top: 2rem;
-    padding-top: 2rem;
-    border-top: 1px solid var(--border-color, #e0e0e0);
+    gap: var(--space-4);
+    margin-top: var(--space-7);
+    padding-top: var(--space-7);
+    border-top: 1px solid var(--color-border);
 }
 
 .page-nav-prev,
 .page-nav-next {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1.25rem;
-    background: var(--card-bg, white);
-    border-radius: var(--border-radius, 8px);
-    color: var(--primary-color);
+    gap: var(--space-2);
+    height: var(--control-md);
+    padding: 0 var(--space-5);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--radius-md);
+    color: var(--color-primary);
     text-decoration: none;
-    font-weight: 500;
-    box-shadow: var(--shadow);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    font-weight: var(--weight-medium);
+    transition: background-color var(--duration-base) var(--ease), border-color var(--duration-base) var(--ease), transform var(--duration-base) var(--ease), box-shadow var(--duration-base) var(--ease);
 }
 
 .page-nav-prev:hover,
 .page-nav-next:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+    background: var(--color-primary-tint);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
 }
 
 .page-nav-prev:empty,
@@ -500,27 +310,16 @@
     visibility: hidden;
 }
 
-/* Dark mode page nav */
-[data-theme="dark"] .page-nav-prev,
-[data-theme="dark"] .page-nav-next {
-    background: var(--card-bg);
-}
-
-[data-theme="dark"] .page-nav-prev:hover,
-[data-theme="dark"] .page-nav-next:hover {
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
-}
-
-/* ==========================================================================
-   Info Cards
-   ========================================================================== */
-
+/* ---- 提示卡：tip / warning / note 對應 成功 / 警告 / 資訊 ---- */
 .guide-info-card {
-    background: var(--gray-50, #f9fafb);
-    border-radius: var(--border-radius, 8px);
-    padding: 1.25rem;
-    margin: 1.5rem 0;
-    border-left: 4px solid var(--primary-color);
+    margin: var(--space-6) 0;
+    padding: var(--space-4) var(--space-5);
+    background: var(--color-info-tint);
+    border: 1px solid var(--color-info-border);
+    border-radius: var(--radius-md);
+    color: var(--color-info-text);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
 }
 
 .guide-info-card strong {
@@ -528,298 +327,56 @@
 }
 
 .guide-tip {
-    background: linear-gradient(135deg, #e8f5e9 0%, #c8e6c9 100%);
-    border-left-color: #4caf50;
-}
-
-.guide-tip strong {
-    color: #2e7d32;
+    background: var(--color-success-tint);
+    border-color: var(--color-success-border);
+    color: var(--color-success-text);
 }
 
 .guide-warning {
-    background: linear-gradient(135deg, #fff3e0 0%, #ffe0b2 100%);
-    border-left-color: #ff9800;
-}
-
-.guide-warning strong {
-    color: #e65100;
+    background: var(--color-warning-tint);
+    border-color: var(--color-warning-border);
+    color: var(--color-warning-text);
 }
 
 .guide-note {
-    background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
-    border-left-color: var(--primary-color);
+    background: var(--color-info-tint);
+    border-color: var(--color-info-border);
+    color: var(--color-info-text);
 }
 
-.guide-note strong {
-    color: #1565c0;
-}
-
-/* ==========================================================================
-   Dark Mode
-   ========================================================================== */
-
-[data-theme="dark"] .toc-container {
-    background: var(--card-bg);
-}
-
-[data-theme="dark"] .toc-link:hover {
-    background: var(--hover-bg, rgba(255, 255, 255, 0.1));
-}
-
-[data-theme="dark"] .guide-section {
-    background: var(--card-bg);
-}
-
-[data-theme="dark"] .guide-section:hover {
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-}
-
-[data-theme="dark"] .search-results-info {
-    background: var(--bg-secondary, #252836);
-}
-
-[data-theme="dark"] .search-highlight {
-    background: linear-gradient(180deg, transparent 50%, rgba(90, 159, 240, 0.3) 50%);
-}
-
-[data-theme="dark"] .section-content h3 {
-    color: var(--text-color);
-}
-
-/* Dark mode info cards */
-[data-theme="dark"] .guide-info-card {
-    background: var(--bg-secondary, #252836);
-}
-
-[data-theme="dark"] .guide-tip {
-    background: linear-gradient(135deg, #1b3d1b 0%, #2d4d2d 100%);
-}
-
-[data-theme="dark"] .guide-tip strong {
-    color: #81c784;
-}
-
-[data-theme="dark"] .guide-warning {
-    background: linear-gradient(135deg, #3d2e00 0%, #4d3b00 100%);
-}
-
-[data-theme="dark"] .guide-warning strong {
-    color: #ffb74d;
-}
-
-[data-theme="dark"] .guide-note {
-    background: linear-gradient(135deg, #1a2d3d 0%, #2a3d4d 100%);
-}
-
-[data-theme="dark"] .guide-note strong {
-    color: #64b5f6;
-}
-
-/* ==========================================================================
-   Responsive Design
-   ========================================================================== */
-
-/* Tablet */
-@media (max-width: 1024px) {
-    .landing-title {
-        font-size: 2rem;
-    }
-
-    .guide-cards-grid {
-        gap: 1.5rem;
-    }
-
-    .toc-sidebar {
-        width: 220px;
-    }
-
-    .guide-layout {
-        gap: 2rem;
-    }
-
-    .guide-section {
-        padding: 2rem;
-    }
-
-    .guide-article {
-        padding: 2rem;
-    }
-
-    .article-title {
-        font-size: 1.75rem;
-    }
-}
-
-/* Mobile */
-@media (max-width: 768px) {
-    .landing-title {
-        font-size: 1.8rem;
-    }
-
-    .landing-subtitle {
-        font-size: 1rem;
-        margin-bottom: 2rem;
-    }
-
-    .guide-cards-grid {
-        grid-template-columns: 1fr;
-        gap: 1rem;
-    }
-
-    .guide-card {
-        padding: 1.5rem;
-    }
-
-    .guide-card-icon {
-        font-size: 2.5rem;
-    }
-
-    .guide-card-title {
-        font-size: 1.2rem;
-    }
-
-    .guide-layout {
-        flex-direction: column;
-    }
-
-    .toc-sidebar {
-        position: relative;
-        top: 0;
-        width: 100%;
-        max-height: none;
-        margin-bottom: 2rem;
-    }
-
-    .toc-container {
-        max-height: 350px;
-        overflow-y: auto;
-    }
-
-    .guide-section {
-        padding: 1.5rem;
-    }
-
-    .section-title {
-        font-size: 1.4rem;
-    }
-
-    .section-content h3 {
-        font-size: 1.15rem;
-    }
-
-    .guide-article {
-        padding: 1.5rem;
-    }
-
-    .article-title {
-        font-size: 1.5rem;
-    }
-
-    .article-content h2 {
-        font-size: 1.3rem;
-    }
-
-    .page-nav {
-        flex-direction: column;
-        gap: 1rem;
-    }
-
-    .page-nav-prev,
-    .page-nav-next {
-        width: 100%;
-        justify-content: center;
-    }
-}
-
-/* Small Mobile */
-@media (max-width: 480px) {
-    .guide-landing {
-        padding: 2rem 0;
-    }
-
-    .landing-title {
-        font-size: 1.5rem;
-    }
-
-    .guide-card {
-        padding: 1.25rem;
-    }
-
-    .guide-section {
-        padding: 1.25rem;
-        border-radius: var(--border-radius, 8px);
-    }
-
-    .section-title {
-        font-size: 1.25rem;
-        flex-wrap: wrap;
-    }
-
-    .toc-container {
-        padding: 1rem;
-    }
-
-    .toc-link {
-        padding: 0.5rem 0.6rem;
-        font-size: 0.9rem;
-    }
-
-    .guide-info-card {
-        padding: 1rem;
-    }
-
-    .guide-article {
-        padding: 1.25rem;
-        border-radius: var(--border-radius, 8px);
-    }
-
-    .article-title {
-        font-size: 1.3rem;
-        flex-wrap: wrap;
-    }
-
-    .page-nav-prev,
-    .page-nav-next {
-        padding: 0.6rem 1rem;
-        font-size: 0.9rem;
-    }
-}
-
-/* ==========================================================================
-   Chocobo Color Calculator
-   ========================================================================== */
-
+/* ---- 陸行鳥毛色計算機（chocobo.html） ---- */
 .color-calculator {
-    background: var(--gray-50, #f9fafb);
-    border-radius: var(--border-radius-lg, 12px);
-    padding: 1.5rem;
-    margin: 1.5rem 0;
+    margin: var(--space-6) 0;
+    padding: var(--space-6);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
 }
 
 .color-select-row {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 1.5rem;
+    gap: var(--space-6);
     flex-wrap: wrap;
 }
 
 .color-select-group {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: var(--space-2);
 }
 
 .color-select-group label {
-    font-weight: 600;
-    color: var(--text-color);
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
 }
 
 .color-select-wrapper {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: var(--space-3);
 }
 
 .color-select-wrapper select {
@@ -829,49 +386,49 @@
 .color-preview {
     width: 40px;
     height: 40px;
-    border-radius: 50%;
-    border: 3px solid var(--border-color, #e0e0e0);
-    box-shadow: var(--shadow);
     flex-shrink: 0;
-    transition: background-color 0.3s ease;
+    border: 3px solid var(--color-border);
+    border-radius: var(--radius-full);
+    box-shadow: var(--shadow-sm);
+    transition: background-color var(--duration-slow) var(--ease);
 }
 
 .color-arrow {
-    font-size: 1.5rem;
-    color: var(--text-secondary, #666);
     flex-shrink: 0;
+    font-size: var(--text-2xl);
+    color: var(--color-muted);
 }
 
 .calculator-actions {
     display: flex;
     justify-content: center;
-    margin-top: 1.5rem;
+    margin-top: var(--space-6);
 }
 
 .result-area {
-    margin-top: 1.5rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid var(--border-color, #e0e0e0);
+    margin-top: var(--space-6);
+    padding-top: var(--space-6);
+    border-top: 1px solid var(--color-border);
 }
 
 .result-area h4 {
-    margin: 0 0 1rem 0;
-    color: var(--primary-color);
-    font-size: 1.1rem;
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-lg);
+    color: var(--color-heading);
 }
 
 .fruit-list {
     list-style: none;
     padding: 0;
-    margin: 0 0 1rem 0;
+    margin: 0 0 var(--space-4);
 }
 
 .fruit-item {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 0.6rem 0;
-    border-bottom: 1px solid var(--border-color, #e0e0e0);
+    gap: var(--space-3);
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--color-border);
 }
 
 .fruit-item:last-child {
@@ -879,80 +436,120 @@
 }
 
 .fruit-item.same-color {
-    color: var(--text-secondary);
+    color: var(--color-muted);
     font-style: italic;
 }
 
 .fruit-color-dot {
     width: 16px;
     height: 16px;
-    border-radius: 50%;
     flex-shrink: 0;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    border-radius: var(--radius-full);
+    box-shadow: var(--shadow-sm);
 }
 
 .fruit-name {
-    font-weight: 500;
-    color: var(--text-color);
+    font-weight: var(--weight-medium);
+    color: var(--color-text);
 }
 
 .fruit-count {
-    color: var(--primary-color);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
+    color: var(--color-primary);
 }
 
 .feeding-order {
-    margin-top: 1rem;
+    margin-top: var(--space-4);
 }
 
 .feeding-order-container {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.4rem;
+    gap: var(--space-1);
 }
 
+/* 顏色由 chocobo-color-calculator.js 以 inline style 指定（果實顏色是資料，不是主題） */
 .feeding-step {
-    padding: 0.3rem 0.6rem;
-    border-radius: var(--border-radius-sm, 6px);
-    font-size: 0.8rem;
-    font-weight: 500;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
-    transition: transform 0.2s ease;
-}
-
-.feeding-step:hover {
-    transform: scale(1.05);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
+    font-weight: var(--weight-medium);
+    box-shadow: var(--shadow-sm);
 }
 
 .feeding-arrow {
-    color: var(--text-secondary, #6b7280);
-    font-size: 1rem;
-    padding: 0 0.2rem;
+    padding: 0 var(--space-1);
+    font-size: var(--text-md);
+    color: var(--color-muted);
     user-select: none;
 }
 
-/* Dark mode for calculator */
-[data-theme="dark"] .color-calculator {
-    background: var(--bg-secondary, #252836);
-}
-
-[data-theme="dark"] .color-preview {
-    border-color: var(--border-color);
-}
-
-[data-theme="dark"] .fruit-item {
-    border-bottom-color: var(--border-color);
-}
-
-[data-theme="dark"] .feeding-arrow {
-    color: var(--text-secondary, #9ca3af);
-}
-
-/* Responsive for calculator */
+/* ---- 響應式 ---- */
 @media (max-width: 768px) {
+    .landing-title {
+        font-size: var(--text-3xl);
+    }
+
+    .landing-subtitle {
+        margin-bottom: var(--space-7);
+        font-size: var(--text-md);
+    }
+
+    .guide-cards-grid {
+        grid-template-columns: 1fr;
+        gap: var(--space-4);
+    }
+
+    .guide-card {
+        padding: var(--space-6);
+    }
+
+    .guide-layout {
+        flex-direction: column;
+        gap: var(--space-6);
+    }
+
+    .toc-sidebar {
+        position: relative;
+        top: 0;
+        width: 100%;
+        max-height: none;
+    }
+
+    .toc-container {
+        max-height: 350px;
+        overflow-y: auto;
+    }
+
+    .guide-article {
+        padding: var(--space-6);
+    }
+
+    .article-title {
+        font-size: var(--text-2xl);
+    }
+
+    .article-icon {
+        font-size: var(--text-2xl);
+    }
+
+    .article-content h2 {
+        font-size: var(--text-xl);
+    }
+
+    .page-nav {
+        flex-direction: column;
+    }
+
+    .page-nav-prev,
+    .page-nav-next {
+        width: 100%;
+        justify-content: center;
+    }
+
     .color-select-row {
         flex-direction: column;
-        gap: 1rem;
+        gap: var(--space-4);
     }
 
     .color-arrow {
@@ -965,32 +562,53 @@
 }
 
 @media (max-width: 480px) {
+    .guide-landing {
+        padding: var(--space-7) 0;
+    }
+
+    .landing-title {
+        font-size: var(--text-2xl);
+    }
+
+    .guide-card {
+        padding: var(--space-5);
+    }
+
+    .toc-container {
+        padding: var(--space-4);
+    }
+
+    .guide-article {
+        padding: var(--space-5);
+    }
+
+    .article-title {
+        font-size: var(--text-xl);
+        flex-wrap: wrap;
+    }
+
+    .guide-info-card {
+        padding: var(--space-3) var(--space-4);
+    }
+
     .color-calculator {
-        padding: 1rem;
+        padding: var(--space-4);
     }
 
     .color-select-wrapper select {
         min-width: 120px;
-        font-size: 0.9rem;
     }
 
     .color-preview {
         width: 32px;
         height: 32px;
     }
-
-    .feeding-step {
-        padding: 0.25rem 0.5rem;
-        font-size: 0.75rem;
-    }
 }
 
-/* ==========================================================================
-   Print Styles
-   ========================================================================== */
-
+/* ---- 列印 ---- */
 @media print {
-    .toc-sidebar {
+    .toc-sidebar,
+    .page-nav {
         display: none;
     }
 
@@ -998,9 +616,8 @@
         display: block;
     }
 
-    .guide-section {
-        break-inside: avoid;
+    .guide-article {
         box-shadow: none;
-        border: 1px solid #ddd;
+        border: 1px solid var(--color-border);
     }
 }

--- a/tools/lodestone-lookup/index.html
+++ b/tools/lodestone-lookup/index.html
@@ -16,6 +16,10 @@
     <meta property="og:image" content="https://ff14.tw/assets/images/og-image.png">
 
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">

--- a/tools/macro-converter/index.html
+++ b/tools/macro-converter/index.html
@@ -6,6 +6,10 @@
     <title>巨集轉換器 - FF14.tw</title>
     <meta name="description" content="FF14 巨集語言轉換工具，支援繁體中文、英文、日文巨集互相轉換">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">

--- a/tools/macro-converter/index.html
+++ b/tools/macro-converter/index.html
@@ -50,7 +50,7 @@
 
                 <!-- Macro Panels -->
                 <div class="macro-panels">
-                    <div class="macro-panel">
+                    <div class="macro-panel card">
                         <div class="panel-header">
                             <label for="inputMacro" data-i18n="macro_converter_input">輸入巨集</label>
                         </div>
@@ -68,7 +68,7 @@
                         </button>
                     </div>
 
-                    <div class="macro-panel">
+                    <div class="macro-panel card">
                         <div class="panel-header">
                             <label for="outputMacro" data-i18n="macro_converter_output">輸出結果</label>
                         </div>
@@ -81,7 +81,6 @@
 
                 <!-- Warning Message -->
                 <div id="warningMessage" class="warning-message" style="display: none;">
-                    <span class="warning-icon-large">⚠</span>
                     <span data-i18n="macro_converter_warning">部分指令無法翻譯</span>
                 </div>
 

--- a/tools/macro-converter/style.css
+++ b/tools/macro-converter/style.css
@@ -1,23 +1,26 @@
-/* Macro Converter Tool Styles */
+/* ==========================================================================
+   巨集轉換器 — 只寫版面；顏色、圓角、字級一律來自 tokens.css 與共用元件
+   ========================================================================== */
 
-/* Language Selector */
+/* 目標語言 */
 .language-selectors {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 2rem;
+    gap: var(--space-2);
+    margin-bottom: var(--space-7);
 }
 
 .language-selectors .form-group {
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: var(--space-4);
+    margin-bottom: 0;
 }
 
 .language-selectors label {
-    font-weight: 500;
-    color: var(--text-secondary);
+    font-weight: var(--weight-medium);
+    color: var(--color-muted);
     white-space: nowrap;
 }
 
@@ -26,59 +29,51 @@
 }
 
 .auto-detect-hint {
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    opacity: 0.8;
     margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-muted);
 }
 
-/* Macro Panels */
+/* 輸入 / 轉換 / 輸出 三欄 */
 .macro-panels {
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    gap: 1.5rem;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    gap: var(--space-6);
     align-items: stretch;
 }
 
+/* 外觀由 .card 提供，這裡只補內距 */
 .macro-panel {
-    display: flex;
-    flex-direction: column;
-    background: var(--surface);
-    border-radius: var(--border-radius-lg);
-    padding: 1rem;
-    border: 1px solid var(--border);
+    padding: var(--space-5);
 }
 
 .panel-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 0.75rem;
+    margin-bottom: var(--space-3);
 }
 
 .panel-header label {
-    font-weight: 600;
-    color: var(--text-primary);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
 }
 
 .macro-textarea {
     flex: 1;
     min-height: 250px;
-    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
-    font-size: 0.9rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     line-height: 1.5;
-    resize: vertical;
 }
-
 
 .panel-actions {
     display: flex;
-    gap: 0.5rem;
-    margin-top: 0.75rem;
     justify-content: flex-end;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
 }
 
-/* Convert Button */
 .convert-button-container {
     display: flex;
     align-items: center;
@@ -87,51 +82,24 @@
 
 .convert-btn {
     white-space: nowrap;
-    padding: 1rem 2rem;
-    font-size: 1.1rem;
 }
 
-/* Warning Message */
 .warning-message {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 1rem;
-    background: rgba(255, 152, 0, 0.1);
-    border: 1px solid rgba(255, 152, 0, 0.3);
-    border-radius: var(--border-radius-md);
-    color: #e65100;
-    margin-top: 1.5rem;
+    margin-top: var(--space-6);
 }
 
-.warning-icon-large {
-    font-size: 1.5rem;
-}
-
-/* Dark mode adjustments */
-[data-theme="dark"] .macro-panel {
-    background: var(--surface);
-}
-
-
-[data-theme="dark"] .warning-message {
-    background: rgba(255, 152, 0, 0.1);
-    border-color: rgba(255, 152, 0, 0.3);
-    color: #ffb74d;
-}
-
-/* Responsive design */
-@media (max-width: 900px) {
+/* 響應式 */
+@media (max-width: 768px) {
     .macro-panels {
         grid-template-columns: 1fr;
     }
 
-    .convert-button-container {
-        order: 1;
-    }
-
     .macro-panel:first-child {
         order: 0;
+    }
+
+    .convert-button-container {
+        order: 1;
     }
 
     .macro-panel:last-child {
@@ -146,7 +114,7 @@
 @media (max-width: 480px) {
     .language-selectors .form-group {
         flex-direction: column;
-        gap: 0.5rem;
+        gap: var(--space-2);
     }
 
     .macro-textarea {

--- a/tools/mini-cactpot/index.html
+++ b/tools/mini-cactpot/index.html
@@ -6,6 +6,10 @@
     <title>仙人微彩計算機 - FF14.tw</title>
     <meta name="description" content="FF14 仙人微彩最佳策略計算工具，分析期望值並推薦最佳選擇">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">

--- a/tools/mini-cactpot/style.css
+++ b/tools/mini-cactpot/style.css
@@ -1,4 +1,3 @@
-@import url('/assets/css/tools-common.css');
 
 :root {
     --cactpot-btn-grad-start: #667eea;

--- a/tools/report-generator/index.html
+++ b/tools/report-generator/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
+    <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -32,8 +33,8 @@
                 <p class="description">快速產生不當行為檢舉的模板文字，協助您進行申訴</p>
             </div>
 
-            <div class="tool-content">
-                <form id="reportForm" class="report-form">
+            <div class="tool-content container-narrow">
+                <form id="reportForm" class="report-form card">
                     <!-- 發生日期 -->
                     <div class="form-group">
                         <label for="incidentDate" class="form-label">發生日期 <span class="required">*</span></label>
@@ -124,7 +125,7 @@
                     <div id="charCountDisplay" class="char-count-display">
                         <span id="charCount">0</span> / 1000 字
                     </div>
-                    <div id="charLimitWarning" class="char-limit-warning hidden">
+                    <div id="charLimitWarning" class="error-message hidden">
                         超過 1000 字限制！請精簡內容後再提交檢舉。
                     </div>
 

--- a/tools/report-generator/index.html
+++ b/tools/report-generator/index.html
@@ -6,6 +6,10 @@
     <title>檢舉模板產生器 - FF14.tw</title>
     <meta name="description" content="快速產生 FF14 繁中版不當行為檢舉的模板文字，協助玩家進行申訴">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">

--- a/tools/report-generator/style.css
+++ b/tools/report-generator/style.css
@@ -1,80 +1,38 @@
-/**
- * FF14.tw 檢舉模板產生器樣式
- */
+/* ==========================================================================
+   檢舉模板產生器 — 只寫版面；顏色、圓角、字級一律來自 tokens.css 與共用元件
+   ========================================================================== */
 
-/* 隱藏元素 */
 .hidden {
     display: none;
 }
 
-/* Noscript 導航樣式 */
+/* 無 JavaScript 時的導覽列 */
 .noscript-nav {
-    padding: 1rem;
-    background: #667eea;
-    color: white;
+    padding: var(--space-4);
+    background: var(--gradient-brand);
+    color: var(--header-text);
     text-align: center;
 }
 
 .noscript-nav-link {
-    color: white;
-    margin: 0 1rem;
+    color: var(--header-text);
+    margin: 0 var(--space-4);
 }
 
-/* 頁面標題區 */
 .page-header {
     text-align: center;
-    margin-bottom: 2rem;
+    margin-bottom: var(--space-7);
 }
 
-.page-header .description {
-    font-size: 1.1rem;
-    color: var(--text-secondary);
-    margin: 0;
-}
-
-/* 工具內容區 */
-.tool-content {
-    max-width: 700px;
-    margin: 0 auto;
-}
-
-/* 表單樣式 */
+/* 表單：外觀由 .card 提供，這裡只補內距 */
 .report-form {
-    background: var(--surface, #ffffff);
-    border-radius: 12px;
-    padding: 2rem;
-    box-shadow: var(--shadow-md);
-}
-
-[data-theme="dark"] .report-form {
-    background: var(--card-bg);
-}
-
-/* 表單群組 */
-.form-group {
-    margin-bottom: 1.5rem;
-}
-
-.form-label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: 0.5rem;
-    color: var(--text-color);
+    padding: var(--space-7);
 }
 
 .required {
-    color: var(--danger-color, #dc3545);
+    color: var(--color-danger);
 }
 
-/* 表單說明文字 */
-.form-text {
-    display: block;
-    margin-top: 0.5rem;
-    font-size: 0.875rem;
-    color: var(--text-muted, #999);
-}
-
-/* Fieldset 重置樣式 */
 .form-group fieldset {
     border: none;
     padding: 0;
@@ -84,14 +42,13 @@
 
 .form-group fieldset legend {
     padding: 0;
-    margin-bottom: 0.5rem;
+    margin-bottom: var(--space-2);
 }
 
-/* 時間範圍輸入 */
 .time-range {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: var(--space-3);
 }
 
 .time-input {
@@ -100,64 +57,73 @@
 }
 
 .time-separator {
-    color: var(--text-secondary);
-    font-weight: 500;
+    color: var(--color-muted);
+    font-weight: var(--weight-medium);
 }
 
-/* 自訂輸入框 */
 .custom-input {
-    margin-top: 0.75rem;
+    margin-top: var(--space-3);
 }
 
-/* 按鈕群組 */
 .button-group {
     display: flex;
-    gap: 1rem;
-    margin-top: 2rem;
+    gap: var(--space-4);
+    margin-top: var(--space-7);
 }
 
 .button-group .btn {
     flex: 1;
 }
 
-/* 結果區塊 */
+/* 結果區 */
 .result-section {
-    margin-top: 3rem;
-    padding-top: 2rem;
-    border-top: 2px solid var(--border, #e0e0e0);
+    margin-top: var(--space-9);
+    padding-top: var(--space-7);
+    border-top: 1px solid var(--color-border);
 }
 
 .result-title {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin-bottom: 1.5rem;
-    color: var(--text-color);
+    margin-bottom: var(--space-6);
+    font-size: var(--text-2xl);
+    font-weight: var(--weight-semibold);
+    color: var(--color-heading);
 }
 
-/* 結果文字 */
 .result-text {
+    margin: 0;
+    padding: var(--space-6);
     white-space: pre-wrap;
     word-wrap: break-word;
     font-family: inherit;
-    font-size: 0.95rem;
-    line-height: 1.8;
-    margin: 0;
-    padding: 1.5rem;
-    background: var(--background, #f8f9fa);
-    border-radius: 8px;
-    color: var(--text-color);
+    font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text);
+    background: var(--color-surface-2);
+    border-radius: var(--radius-md);
 }
 
-[data-theme="dark"] .result-text {
-    background: var(--bg-secondary);
+.char-count-display {
+    margin-top: var(--space-2);
+    text-align: right;
+    font-size: var(--text-sm);
+    color: var(--color-muted);
 }
 
-/* 動作按鈕區 */
+.char-count-display.over-limit {
+    color: var(--color-danger-text);
+    font-weight: var(--weight-semibold);
+}
+
+#charLimitWarning {
+    margin-top: var(--space-4);
+    font-weight: var(--weight-medium);
+}
+
 .action-buttons {
     display: flex;
-    gap: 1rem;
-    margin-top: 1.5rem;
     flex-wrap: wrap;
+    gap: var(--space-4);
+    margin-top: var(--space-6);
 }
 
 .action-buttons .btn {
@@ -165,68 +131,19 @@
     min-width: 200px;
 }
 
-/* 按鈕圖示 */
-.btn-icon {
-    margin-right: 0.5rem;
-}
-
-/* 複製成功狀態 */
+/* 複製完成的回饋（script.js 暫時加上 btn-success-active） */
 #copyBtn.btn-success-active {
-    background-color: var(--success-color, #28a745);
-    border-color: var(--success-color, #28a745);
+    background: var(--color-success-text);
 }
 
-/* 警告訊息 */
 .warning-message {
-    margin-top: 1.5rem;
-    padding: 1rem 1.25rem;
-    background: linear-gradient(135deg, #fff3cd 0%, #ffeaa7 100%);
-    border: 1px solid #ffc107;
-    border-radius: 8px;
-    color: #856404;
-    font-size: 0.95rem;
+    margin-top: var(--space-6);
 }
 
-[data-theme="dark"] .warning-message {
-    background: linear-gradient(135deg, rgba(255, 193, 7, 0.2) 0%, rgba(255, 193, 7, 0.1) 100%);
-    border-color: rgba(255, 193, 7, 0.5);
-    color: #ffc107;
-}
-
-/* 字數統計顯示 */
-.char-count-display {
-    text-align: right;
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
-.char-count-display.over-limit {
-    color: var(--danger-color, #dc3545);
-    font-weight: 600;
-}
-
-/* 字數限制警告 */
-.char-limit-warning {
-    margin-top: 1rem;
-    padding: 1rem;
-    background: linear-gradient(135deg, #f8d7da 0%, #f5c6cb 100%);
-    border: 1px solid #dc3545;
-    border-radius: 8px;
-    color: #721c24;
-    font-weight: 500;
-}
-
-[data-theme="dark"] .char-limit-warning {
-    background: linear-gradient(135deg, rgba(220, 53, 69, 0.2) 0%, rgba(220, 53, 69, 0.1) 100%);
-    border-color: rgba(220, 53, 69, 0.5);
-    color: #f5c6cb;
-}
-
-/* 響應式設計 */
+/* 響應式 */
 @media (max-width: 768px) {
     .report-form {
-        padding: 1.5rem;
+        padding: var(--space-6);
     }
 
     .time-range {
@@ -240,13 +157,10 @@
 
     .time-separator {
         text-align: center;
-        padding: 0.25rem 0;
+        padding: var(--space-1) 0;
     }
 
-    .button-group {
-        flex-direction: column;
-    }
-
+    .button-group,
     .action-buttons {
         flex-direction: column;
     }
@@ -257,16 +171,11 @@
 }
 
 @media (max-width: 480px) {
-    .page-header .description {
-        font-size: 1rem;
-    }
-
     .report-form {
-        padding: 1.25rem;
+        padding: var(--space-5);
     }
 
     .result-text {
-        padding: 1rem;
-        font-size: 0.9rem;
+        padding: var(--space-4);
     }
 }

--- a/tools/timed-gathering/index.html
+++ b/tools/timed-gathering/index.html
@@ -6,6 +6,10 @@
     <title data-i18n="pageTitle">特殊採集時間管理器</title>
     <meta name="description" content="FF14 特殊採集時間管理工具，支援搜尋、多清單管理、巨集匯出功能" data-i18n="pageDescription" data-i18n-attr="content">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">

--- a/tools/treasure-map-finder/index.html
+++ b/tools/treasure-map-finder/index.html
@@ -6,6 +6,10 @@
     <title>寶圖搜尋器 - FF14.tw</title>
     <meta name="description" content="FF14 寶圖位置快速查詢工具，支援多條件篩選與個人清單管理">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">

--- a/tools/weather-forecast/index.html
+++ b/tools/weather-forecast/index.html
@@ -6,14 +6,15 @@
     <title>天氣預報 - FF14.tw</title>
     <meta name="description" content="查看艾歐澤亞各地區的天氣預報，搜尋特定天氣條件，追蹤特殊事件">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">
     <link rel="stylesheet" href="../../assets/css/components/language-switcher.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <div id="header-placeholder" data-base-path="../../" data-tool-name="天氣預報" data-tool-name-key="weather_header"></div>

--- a/tools/weather-forecast/style.css
+++ b/tools/weather-forecast/style.css
@@ -372,6 +372,7 @@
 .toast.show {
     opacity: 1;
     visibility: visible;
+    transform: translateX(-50%);
 }
 
 /* Dark Mode 支援 */

--- a/tools/wondrous-tails/index.html
+++ b/tools/wondrous-tails/index.html
@@ -6,6 +6,10 @@
     <title>天書奇談預測器 - FF14.tw</title>
     <meta name="description" content="FF14 天書奇談機率預測工具，計算連線成功機率">
     <link rel="icon" type="image/x-icon" href="../../assets/images/ff14tw.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/tokens.css">
     <link rel="stylesheet" href="../../assets/css/common.css">
     <link rel="stylesheet" href="../../assets/css/dark-mode-tools.css">
     <link rel="stylesheet" href="../../assets/css/tools-common.css">

--- a/tools/wondrous-tails/style.css
+++ b/tools/wondrous-tails/style.css
@@ -1,4 +1,3 @@
-@import url('/assets/css/tools-common.css');
 
 /* Wondrous Tails Calculator Styles */
 


### PR DESCRIPTION
## 摘要

Plan 1「設計系統基礎落地」：把全站散落的顏色、字級、圓角、陰影收斂成一份 token，並讓共用元件只讀 token；三個低分歧工具先遷移作為範例。設計依據是已定案的設計畫布（方向 A · 靛藍統一）。

盤點時的現況：12 個工具＋4 個頁面約 12,500 行 CSS 裡有 307 種顏色值、61 個從未定義的 CSS 變數、18 種圓角、105 種陰影、40 種字級、5 套語意色票、3 套深色調色盤，9 個頁面沒載入 Noto Sans TC。

## 變更內容

- **`assets/css/tokens.css`**：全站唯一的顏色／字級／間距／圓角／陰影／動態來源，淺色 `:root` ＋ 深色 `[data-theme="dark"]`。
- **`assets/css/common.css`**：改讀 token；頂部保留「舊名稱 → 新 token」相容別名層（`--primary-color`、`--dark-color`…），讓尚未遷移的 9 個工具在過渡期不壞；移除重複的第二套 `.btn`。
- **每一頁（23 頁）**：統一載入 Noto Sans TC 400/500/600/700 與 `tokens.css`（`scripts/add-design-links.mjs`，可重跑）；移除 5 個工具重複 `@import` tools-common。
- **共用元件整檔改寫（只讀 token、無 dark 規則）**：`buttons.css`、`forms.css`、`tags.css`（標籤／篩選膠囊／徽章）、`cards.css`、`tools-common.css`（訊息／載入／toast）、`language-switcher.css`。
- **遷移三個工具**為「只寫版面」的 CSS：巨集轉換器、檢舉模板產生器、攻略資料。
- **守門測試**：`tests/design-system.test.js`（深色完整性、關鍵配色 ≥ 4.5:1、token-clean 清單：禁色碼／未定義 `var()`／`@import`／`!important`／自帶 `[data-theme]` 規則）與 `tests/pages.test.js`（每頁載入順序與字型）。執行：`node --test`。
- changelog v2.13.0、CLAUDE.md（token 規則、載入順序、測試指令）。

## 玩家看得到的變化

- 主色由天藍 `#4a90e2`（白字對比 3.3:1）改為靛藍 `#5061d3`（5.3:1）；頁首與首頁 hero 的紫色漸層保留。
- `.btn-secondary` 不再誤顯示為橘色；`h2` 改為標題色；全站連結色統一。
- 副本資料庫深色模式的標題不再隱形；巨集轉換器面板有底色了；特殊採集搜尋框左側空白消失。
- 深色模式下首頁／關於／版權的 hero 改為較沉的品牌漸層。
- 未遷移的 9 個工具靠相容別名層維持原本外觀（Plan 2／3 逐一遷移）。

## 測試

- `node --test` → 8/8 通過。
- 每個任務都有獨立的 spec＋品質審查；整支分支最終審查在一輪修正後乾淨（瀏覽器實測淺色＋深色：檢舉模板、巨集轉換器、攻略頁、副本資料庫、特殊採集）。

## 不在本 PR（後續計畫）

- Plan 2：副本資料庫、特殊採集、天氣預報、天書奇談、仙人微彩；tools-common 補頁籤／開關／進度／格子／表格。
- Plan 3：寶圖搜尋器、Lodestone、宗長、角色卡；首頁／關於／版權／修改紀錄的內嵌樣式；刪除 `dark-mode-tools.css` 與相容別名層。
- 已知過渡期項目：副本資料庫仍用自己的 `.image-placeholder`（repo 內沒有副本圖片，佔位圖是常態）；特殊採集的深色 `.tag-filter.active` 覆寫；`FF14Utils.showToast` 仍用內聯樣式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
